### PR TITLE
Add JS API integration for web front-end

### DIFF
--- a/conViver.Web/index.html
+++ b/conViver.Web/index.html
@@ -21,20 +21,20 @@
         <section class="dashboard__metrics">
             <div class="cv-card dashboard__metric">
                 <h2 class="dashboard__metric-title">Inadimplência</h2>
-                <p class="dashboard__metric-value">--%</p>
+                <p class="dashboard__metric-value js-inadimplencia">--%</p>
             </div>
             <div class="cv-card dashboard__metric">
                 <h2 class="dashboard__metric-title">Saldo em Conta</h2>
-                <p class="dashboard__metric-value">R$ --</p>
+                <p class="dashboard__metric-value js-saldo">R$ --</p>
             </div>
             <div class="cv-card dashboard__metric">
                 <h2 class="dashboard__metric-title">Próximas Despesas</h2>
-                <ul class="dashboard__metric-list">
+                <ul class="dashboard__metric-list js-proximas-despesas">
                     <li>...</li>
                 </ul>
             </div>
         </section>
     </main>
-    <script src="js/dashboard.js"></script>
+    <script type="module" src="js/dashboard.js"></script>
 </body>
 </html>

--- a/conViver.Web/js/apiClient.js
+++ b/conViver.Web/js/apiClient.js
@@ -1,4 +1,34 @@
+const API_BASE = '/api/v1';
+
+export function getToken() {
+    return localStorage.getItem('cv_token');
+}
+
+export function setToken(token) {
+    localStorage.setItem('cv_token', token);
+}
+
+async function request(path, options = {}) {
+    const opts = { ...options, headers: { ...(options.headers || {}) } };
+    const token = getToken();
+    if (token) {
+        opts.headers['Authorization'] = `Bearer ${token}`;
+    }
+    if (opts.body && typeof opts.body !== 'string') {
+        opts.headers['Content-Type'] = 'application/json';
+        opts.body = JSON.stringify(opts.body);
+    }
+    const res = await fetch(`${API_BASE}${path}`, opts);
+    if (!res.ok) throw new Error('API request failed');
+    if (res.status === 204) return null;
+    return res.json();
+}
+
 const apiClient = {
-    get: (url) => fetch(url).then(r => r.json()),
+    get: (url) => request(url),
+    post: (url, data) => request(url, { method: 'POST', body: data }),
+    put: (url, data) => request(url, { method: 'PUT', body: data }),
+    delete: (url) => request(url, { method: 'DELETE' })
 };
+
 export default apiClient;

--- a/conViver.Web/js/comunicacao.js
+++ b/conViver.Web/js/comunicacao.js
@@ -1,0 +1,23 @@
+import apiClient from './apiClient.js';
+
+document.addEventListener('DOMContentLoaded', async () => {
+    await carregarAvisos();
+});
+
+async function carregarAvisos() {
+    try {
+        const resp = await apiClient.get('/app/avisos?page=1&size=10');
+        const avisos = resp.items || resp;
+        const container = document.querySelector('.js-avisos');
+        container.innerHTML = '';
+        avisos.forEach(a => {
+            const art = document.createElement('article');
+            art.className = 'cv-card communication__post';
+            art.innerHTML = `<h3 class="communication__post-title">${a.titulo}</h3>` +
+                `<p class="communication__post-text">${a.corpo || ''}</p>`;
+            container.appendChild(art);
+        });
+    } catch(err) {
+        console.error('Erro ao carregar avisos', err);
+    }
+}

--- a/conViver.Web/js/dashboard.js
+++ b/conViver.Web/js/dashboard.js
@@ -1,1 +1,17 @@
-console.log('dashboard page');
+import apiClient from './apiClient.js';
+
+document.addEventListener('DOMContentLoaded', async () => {
+    try {
+        const metrics = await apiClient.get('/syndic/reports/dashboard');
+        if (metrics.inadimplencia !== undefined) {
+            const val = (metrics.inadimplencia * 100).toFixed(1) + '%';
+            document.querySelector('.js-inadimplencia').textContent = val;
+        }
+        if (metrics.saldoCaixa !== undefined) {
+            document.querySelector('.js-saldo').textContent =
+                `R$ ${metrics.saldoCaixa.toFixed(2)}`;
+        }
+    } catch (err) {
+        console.error('Erro ao carregar dashboard', err);
+    }
+});

--- a/conViver.Web/js/financeiro.js
+++ b/conViver.Web/js/financeiro.js
@@ -1,1 +1,16 @@
-console.log('financeiro page');
+import apiClient from './apiClient.js';
+
+document.addEventListener('DOMContentLoaded', async () => {
+    try {
+        const boletos = await apiClient.get('/syndic/finance/boletos');
+        const tbody = document.querySelector('.js-boletos');
+        tbody.innerHTML = '';
+        boletos.forEach(b => {
+            const tr = document.createElement('tr');
+            tr.innerHTML = `<td>${b.unidadeId.slice(0,4)}</td><td>R$ ${b.valor.toFixed(2)}</td><td>${b.status}</td>`;
+            tbody.appendChild(tr);
+        });
+    } catch (err) {
+        console.error('Erro ao carregar boletos', err);
+    }
+});

--- a/conViver.Web/js/portaria.js
+++ b/conViver.Web/js/portaria.js
@@ -1,0 +1,40 @@
+import apiClient from './apiClient.js';
+
+document.addEventListener('DOMContentLoaded', async () => {
+    await carregarVisitantes();
+    await carregarEncomendas();
+});
+
+async function carregarVisitantes() {
+    try {
+        const hoje = new Date();
+        const from = new Date(hoje.getFullYear(), hoje.getMonth(), hoje.getDate() - 7)
+            .toISOString().slice(0,10);
+        const to = hoje.toISOString().slice(0,10);
+        const visitas = await apiClient.get(`/syndic/visitantes?from=${from}&to=${to}`);
+        const tbody = document.querySelector('.js-visitantes');
+        tbody.innerHTML = '';
+        visitas.forEach(v => {
+            const tr = document.createElement('tr');
+            tr.innerHTML = `<td>${v.nome}</td><td>${v.unidadeId.slice(0,4)}</td><td>${v.status || ''}</td>`;
+            tbody.appendChild(tr);
+        });
+    } catch(err) {
+        console.error('Erro ao listar visitantes', err);
+    }
+}
+
+async function carregarEncomendas() {
+    try {
+        const encomendas = await apiClient.get('/syndic/encomendas?status=recebida');
+        const tbody = document.querySelector('.js-encomendas');
+        tbody.innerHTML = '';
+        encomendas.forEach(e => {
+            const tr = document.createElement('tr');
+            tr.innerHTML = `<td>${e.descricao || ''}</td><td>${e.unidadeId.slice(0,4)}</td><td>${e.status}</td>`;
+            tbody.appendChild(tr);
+        });
+    } catch(err) {
+        console.error('Erro ao listar encomendas', err);
+    }
+}

--- a/conViver.Web/js/reservas.js
+++ b/conViver.Web/js/reservas.js
@@ -1,1 +1,40 @@
-console.log('reservas page');
+import apiClient from './apiClient.js';
+
+document.addEventListener('DOMContentLoaded', () => {
+    carregarAgenda();
+    document.querySelector('.js-reserva-form').addEventListener('submit', criarReserva);
+});
+
+async function carregarAgenda() {
+    try {
+        const now = new Date();
+        const mes = now.toISOString().slice(0,7);
+        const reservas = await apiClient.get(`/app/reservas/agenda?mesAno=${mes}`);
+        const container = document.querySelector('.js-calendario');
+        container.innerHTML = '';
+        reservas.forEach(r => {
+            const div = document.createElement('div');
+            div.className = 'cv-card reservas__day-item';
+            const inicio = new Date(r.inicio).toLocaleDateString('pt-BR');
+            div.textContent = `${inicio} - ${r.area}`;
+            container.appendChild(div);
+        });
+    } catch(err) {
+        console.error('Erro ao carregar agenda', err);
+    }
+}
+
+async function criarReserva(evt) {
+    evt.preventDefault();
+    const data = document.querySelector('.js-reserva-data').value;
+    if (!data) return;
+    const inicio = `${data}T10:00:00`;
+    const fim = `${data}T12:00:00`;
+    try {
+        await apiClient.post('/app/reservas', { area: 'Area Comum', inicio, fim });
+        evt.target.reset();
+        carregarAgenda();
+    } catch(err) {
+        console.error('Erro ao criar reserva', err);
+    }
+}

--- a/conViver.Web/pages/comunicacao.html
+++ b/conViver.Web/pages/comunicacao.html
@@ -18,7 +18,7 @@
         <a href="comunicacao.html" class="cv-nav__link">Comunicação</a>
     </nav>
     <main class="cv-container">
-        <section class="communication__mural">
+        <section class="communication__mural js-avisos">
             <h2 class="communication__title">Mural Digital</h2>
             <article class="cv-card communication__post">
                 <h3 class="communication__post-title">Aviso Importante</h3>
@@ -32,6 +32,6 @@
             </div>
         </section>
     </main>
-    <script src="../js/dashboard.js"></script>
+    <script type="module" src="../js/comunicacao.js"></script>
 </body>
 </html>

--- a/conViver.Web/pages/financeiro.html
+++ b/conViver.Web/pages/financeiro.html
@@ -28,7 +28,7 @@
                         <th>Status</th>
                     </tr>
                 </thead>
-                <tbody>
+                <tbody class="js-boletos">
                     <tr>
                         <td>101</td>
                         <td>R$ --</td>
@@ -47,7 +47,7 @@
                         <th>Valor</th>
                     </tr>
                 </thead>
-                <tbody>
+                <tbody class="js-despesas">
                     <tr>
                         <td>...</td>
                         <td>...</td>
@@ -57,6 +57,6 @@
             </table>
         </section>
     </main>
-    <script src="../js/financeiro.js"></script>
+    <script type="module" src="../js/financeiro.js"></script>
 </body>
 </html>

--- a/conViver.Web/pages/portaria.html
+++ b/conViver.Web/pages/portaria.html
@@ -28,7 +28,7 @@
                         <th>Status</th>
                     </tr>
                 </thead>
-                <tbody>
+                <tbody class="js-visitantes">
                     <tr>
                         <td>...</td>
                         <td>...</td>
@@ -47,7 +47,7 @@
                         <th>Status</th>
                     </tr>
                 </thead>
-                <tbody>
+                <tbody class="js-encomendas">
                     <tr>
                         <td>...</td>
                         <td>...</td>
@@ -57,6 +57,6 @@
             </table>
         </section>
     </main>
-    <script src="../js/dashboard.js"></script>
+    <script type="module" src="../js/portaria.js"></script>
 </body>
 </html>

--- a/conViver.Web/pages/reservas.html
+++ b/conViver.Web/pages/reservas.html
@@ -18,22 +18,22 @@
         <a href="comunicacao.html" class="cv-nav__link">Comunicação</a>
     </nav>
     <main class="cv-container">
-        <section class="reservas__calendar">
+        <section class="reservas__calendar js-calendario">
             <h2 class="reservas__title">Agenda das Áreas Comuns</h2>
             <div class="cv-card reservas__day">Dia 1</div>
             <div class="cv-card reservas__day">Dia 2</div>
         </section>
         <section class="reservas__solicitar">
             <h2 class="reservas__title">Solicitar Reserva</h2>
-            <form class="reservas__form">
+            <form class="reservas__form js-reserva-form">
                 <label class="reservas__label">
                     Data:
-                    <input type="date" class="reservas__input" />
+                    <input type="date" class="reservas__input js-reserva-data" />
                 </label>
                 <button class="reservas__button" type="submit">Enviar</button>
             </form>
         </section>
     </main>
-    <script src="../js/reservas.js"></script>
+    <script type="module" src="../js/reservas.js"></script>
 </body>
 </html>

--- a/conViver.Web/wwwroot/index.html
+++ b/conViver.Web/wwwroot/index.html
@@ -21,20 +21,20 @@
         <section class="dashboard__metrics">
             <div class="cv-card dashboard__metric">
                 <h2 class="dashboard__metric-title">Inadimplência</h2>
-                <p class="dashboard__metric-value">--%</p>
+                <p class="dashboard__metric-value js-inadimplencia">--%</p>
             </div>
             <div class="cv-card dashboard__metric">
                 <h2 class="dashboard__metric-title">Saldo em Conta</h2>
-                <p class="dashboard__metric-value">R$ --</p>
+                <p class="dashboard__metric-value js-saldo">R$ --</p>
             </div>
             <div class="cv-card dashboard__metric">
                 <h2 class="dashboard__metric-title">Próximas Despesas</h2>
-                <ul class="dashboard__metric-list">
+                <ul class="dashboard__metric-list js-proximas-despesas">
                     <li>...</li>
                 </ul>
             </div>
         </section>
     </main>
-    <script src="js/dashboard.js"></script>
+    <script type="module" src="js/dashboard.js"></script>
 </body>
 </html>

--- a/conViver.Web/wwwroot/js/apiClient.js
+++ b/conViver.Web/wwwroot/js/apiClient.js
@@ -1,4 +1,34 @@
+const API_BASE = '/api/v1';
+
+export function getToken() {
+    return localStorage.getItem('cv_token');
+}
+
+export function setToken(token) {
+    localStorage.setItem('cv_token', token);
+}
+
+async function request(path, options = {}) {
+    const opts = { ...options, headers: { ...(options.headers || {}) } };
+    const token = getToken();
+    if (token) {
+        opts.headers['Authorization'] = `Bearer ${token}`;
+    }
+    if (opts.body && typeof opts.body !== 'string') {
+        opts.headers['Content-Type'] = 'application/json';
+        opts.body = JSON.stringify(opts.body);
+    }
+    const res = await fetch(`${API_BASE}${path}`, opts);
+    if (!res.ok) throw new Error('API request failed');
+    if (res.status === 204) return null;
+    return res.json();
+}
+
 const apiClient = {
-    get: (url) => fetch(url).then(r => r.json()),
+    get: (url) => request(url),
+    post: (url, data) => request(url, { method: 'POST', body: data }),
+    put: (url, data) => request(url, { method: 'PUT', body: data }),
+    delete: (url) => request(url, { method: 'DELETE' })
 };
+
 export default apiClient;

--- a/conViver.Web/wwwroot/js/comunicacao.js
+++ b/conViver.Web/wwwroot/js/comunicacao.js
@@ -1,0 +1,23 @@
+import apiClient from './apiClient.js';
+
+document.addEventListener('DOMContentLoaded', async () => {
+    await carregarAvisos();
+});
+
+async function carregarAvisos() {
+    try {
+        const resp = await apiClient.get('/app/avisos?page=1&size=10');
+        const avisos = resp.items || resp;
+        const container = document.querySelector('.js-avisos');
+        container.innerHTML = '';
+        avisos.forEach(a => {
+            const art = document.createElement('article');
+            art.className = 'cv-card communication__post';
+            art.innerHTML = `<h3 class="communication__post-title">${a.titulo}</h3>` +
+                `<p class="communication__post-text">${a.corpo || ''}</p>`;
+            container.appendChild(art);
+        });
+    } catch(err) {
+        console.error('Erro ao carregar avisos', err);
+    }
+}

--- a/conViver.Web/wwwroot/js/dashboard.js
+++ b/conViver.Web/wwwroot/js/dashboard.js
@@ -1,1 +1,17 @@
-console.log('dashboard page');
+import apiClient from './apiClient.js';
+
+document.addEventListener('DOMContentLoaded', async () => {
+    try {
+        const metrics = await apiClient.get('/syndic/reports/dashboard');
+        if (metrics.inadimplencia !== undefined) {
+            const val = (metrics.inadimplencia * 100).toFixed(1) + '%';
+            document.querySelector('.js-inadimplencia').textContent = val;
+        }
+        if (metrics.saldoCaixa !== undefined) {
+            document.querySelector('.js-saldo').textContent =
+                `R$ ${metrics.saldoCaixa.toFixed(2)}`;
+        }
+    } catch (err) {
+        console.error('Erro ao carregar dashboard', err);
+    }
+});

--- a/conViver.Web/wwwroot/js/financeiro.js
+++ b/conViver.Web/wwwroot/js/financeiro.js
@@ -1,1 +1,16 @@
-console.log('financeiro page');
+import apiClient from './apiClient.js';
+
+document.addEventListener('DOMContentLoaded', async () => {
+    try {
+        const boletos = await apiClient.get('/syndic/finance/boletos');
+        const tbody = document.querySelector('.js-boletos');
+        tbody.innerHTML = '';
+        boletos.forEach(b => {
+            const tr = document.createElement('tr');
+            tr.innerHTML = `<td>${b.unidadeId.slice(0,4)}</td><td>R$ ${b.valor.toFixed(2)}</td><td>${b.status}</td>`;
+            tbody.appendChild(tr);
+        });
+    } catch (err) {
+        console.error('Erro ao carregar boletos', err);
+    }
+});

--- a/conViver.Web/wwwroot/js/portaria.js
+++ b/conViver.Web/wwwroot/js/portaria.js
@@ -1,0 +1,40 @@
+import apiClient from './apiClient.js';
+
+document.addEventListener('DOMContentLoaded', async () => {
+    await carregarVisitantes();
+    await carregarEncomendas();
+});
+
+async function carregarVisitantes() {
+    try {
+        const hoje = new Date();
+        const from = new Date(hoje.getFullYear(), hoje.getMonth(), hoje.getDate() - 7)
+            .toISOString().slice(0,10);
+        const to = hoje.toISOString().slice(0,10);
+        const visitas = await apiClient.get(`/syndic/visitantes?from=${from}&to=${to}`);
+        const tbody = document.querySelector('.js-visitantes');
+        tbody.innerHTML = '';
+        visitas.forEach(v => {
+            const tr = document.createElement('tr');
+            tr.innerHTML = `<td>${v.nome}</td><td>${v.unidadeId.slice(0,4)}</td><td>${v.status || ''}</td>`;
+            tbody.appendChild(tr);
+        });
+    } catch(err) {
+        console.error('Erro ao listar visitantes', err);
+    }
+}
+
+async function carregarEncomendas() {
+    try {
+        const encomendas = await apiClient.get('/syndic/encomendas?status=recebida');
+        const tbody = document.querySelector('.js-encomendas');
+        tbody.innerHTML = '';
+        encomendas.forEach(e => {
+            const tr = document.createElement('tr');
+            tr.innerHTML = `<td>${e.descricao || ''}</td><td>${e.unidadeId.slice(0,4)}</td><td>${e.status}</td>`;
+            tbody.appendChild(tr);
+        });
+    } catch(err) {
+        console.error('Erro ao listar encomendas', err);
+    }
+}

--- a/conViver.Web/wwwroot/js/reservas.js
+++ b/conViver.Web/wwwroot/js/reservas.js
@@ -1,1 +1,40 @@
-console.log('reservas page');
+import apiClient from './apiClient.js';
+
+document.addEventListener('DOMContentLoaded', () => {
+    carregarAgenda();
+    document.querySelector('.js-reserva-form').addEventListener('submit', criarReserva);
+});
+
+async function carregarAgenda() {
+    try {
+        const now = new Date();
+        const mes = now.toISOString().slice(0,7);
+        const reservas = await apiClient.get(`/app/reservas/agenda?mesAno=${mes}`);
+        const container = document.querySelector('.js-calendario');
+        container.innerHTML = '';
+        reservas.forEach(r => {
+            const div = document.createElement('div');
+            div.className = 'cv-card reservas__day-item';
+            const inicio = new Date(r.inicio).toLocaleDateString('pt-BR');
+            div.textContent = `${inicio} - ${r.area}`;
+            container.appendChild(div);
+        });
+    } catch(err) {
+        console.error('Erro ao carregar agenda', err);
+    }
+}
+
+async function criarReserva(evt) {
+    evt.preventDefault();
+    const data = document.querySelector('.js-reserva-data').value;
+    if (!data) return;
+    const inicio = `${data}T10:00:00`;
+    const fim = `${data}T12:00:00`;
+    try {
+        await apiClient.post('/app/reservas', { area: 'Area Comum', inicio, fim });
+        evt.target.reset();
+        carregarAgenda();
+    } catch(err) {
+        console.error('Erro ao criar reserva', err);
+    }
+}

--- a/conViver.Web/wwwroot/pages/comunicacao.html
+++ b/conViver.Web/wwwroot/pages/comunicacao.html
@@ -18,7 +18,7 @@
         <a href="comunicacao.html" class="cv-nav__link">Comunicação</a>
     </nav>
     <main class="cv-container">
-        <section class="communication__mural">
+        <section class="communication__mural js-avisos">
             <h2 class="communication__title">Mural Digital</h2>
             <article class="cv-card communication__post">
                 <h3 class="communication__post-title">Aviso Importante</h3>
@@ -32,6 +32,6 @@
             </div>
         </section>
     </main>
-    <script src="../js/dashboard.js"></script>
+    <script type="module" src="../js/comunicacao.js"></script>
 </body>
 </html>

--- a/conViver.Web/wwwroot/pages/financeiro.html
+++ b/conViver.Web/wwwroot/pages/financeiro.html
@@ -28,7 +28,7 @@
                         <th>Status</th>
                     </tr>
                 </thead>
-                <tbody>
+                <tbody class="js-boletos">
                     <tr>
                         <td>101</td>
                         <td>R$ --</td>
@@ -47,7 +47,7 @@
                         <th>Valor</th>
                     </tr>
                 </thead>
-                <tbody>
+                <tbody class="js-despesas">
                     <tr>
                         <td>...</td>
                         <td>...</td>
@@ -57,6 +57,6 @@
             </table>
         </section>
     </main>
-    <script src="../js/financeiro.js"></script>
+    <script type="module" src="../js/financeiro.js"></script>
 </body>
 </html>

--- a/conViver.Web/wwwroot/pages/portaria.html
+++ b/conViver.Web/wwwroot/pages/portaria.html
@@ -28,7 +28,7 @@
                         <th>Status</th>
                     </tr>
                 </thead>
-                <tbody>
+                <tbody class="js-visitantes">
                     <tr>
                         <td>...</td>
                         <td>...</td>
@@ -47,7 +47,7 @@
                         <th>Status</th>
                     </tr>
                 </thead>
-                <tbody>
+                <tbody class="js-encomendas">
                     <tr>
                         <td>...</td>
                         <td>...</td>
@@ -57,6 +57,6 @@
             </table>
         </section>
     </main>
-    <script src="../js/dashboard.js"></script>
+    <script type="module" src="../js/portaria.js"></script>
 </body>
 </html>

--- a/conViver.Web/wwwroot/pages/reservas.html
+++ b/conViver.Web/wwwroot/pages/reservas.html
@@ -18,22 +18,22 @@
         <a href="comunicacao.html" class="cv-nav__link">Comunicação</a>
     </nav>
     <main class="cv-container">
-        <section class="reservas__calendar">
+        <section class="reservas__calendar js-calendario">
             <h2 class="reservas__title">Agenda das Áreas Comuns</h2>
             <div class="cv-card reservas__day">Dia 1</div>
             <div class="cv-card reservas__day">Dia 2</div>
         </section>
         <section class="reservas__solicitar">
             <h2 class="reservas__title">Solicitar Reserva</h2>
-            <form class="reservas__form">
+            <form class="reservas__form js-reserva-form">
                 <label class="reservas__label">
                     Data:
-                    <input type="date" class="reservas__input" />
+                    <input type="date" class="reservas__input js-reserva-data" />
                 </label>
                 <button class="reservas__button" type="submit">Enviar</button>
             </form>
         </section>
     </main>
-    <script src="../js/reservas.js"></script>
+    <script type="module" src="../js/reservas.js"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- wire up API client and token storage
- load dashboard metrics from API
- list boletos on Financeiro page
- fetch reservas and allow creating new ones
- list visitantes and encomendas
- show avisos no mural
- update HTML to use new modules

## Testing
- `dotnet test --no-build --verbosity minimal` *(fails: `dotnet: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_6852d3193ce88332afac2147b755d1d6