### PR TITLE
Fix build and run local dev

### DIFF
--- a/conViver.API/conViver.API.csproj
+++ b/conViver.API/conViver.API.csproj
@@ -13,6 +13,7 @@
     <PackageReference Include="Microsoft.Extensions.Caching.StackExchangeRedis" Version="9.0.6" />
     <PackageReference Include="Serilog.AspNetCore" Version="9.0.0" />
     <PackageReference Include="Swashbuckle.AspNetCore" Version="9.0.1" />
+    <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="8.0.4" />
   </ItemGroup>
 
   <ItemGroup>

--- a/conViver.Application/Services/FinanceiroService.cs
+++ b/conViver.Application/Services/FinanceiroService.cs
@@ -26,10 +26,7 @@ public class FinanceiroService
             Id = Guid.NewGuid(),
             UnidadeId = unidadeId,
             Valor = valor,
-            DataVencimento = vencimento.Date,
-            NossoNumero = Guid.NewGuid().ToString("N").Substring(0, 10),
-            CodigoBanco = "999",
-            Status = BoletoStatus.Gerado
+            DataVencimento = vencimento.Date
         };
 
         await _boletos.AddAsync(boleto, ct);
@@ -66,8 +63,7 @@ public class FinanceiroService
         if (boleto == null) return;
         if (boleto.Status == BoletoStatus.Pago)
             throw new InvalidOperationException("Boleto pago");
-        boleto.Status = BoletoStatus.Cancelado;
-        boleto.UpdatedAt = DateTime.UtcNow;
+        boleto.Cancelar();
         await _boletos.UpdateAsync(boleto, ct);
         await _boletos.SaveChangesAsync(ct);
     }

--- a/conViver.Application/conViver.Application.csproj
+++ b/conViver.Application/conViver.Application.csproj
@@ -6,7 +6,10 @@
 
   <ItemGroup>
     <PackageReference Include="FluentValidation" Version="12.0.0" />
+    <PackageReference Include="FluentValidation.DependencyInjectionExtensions" Version="12.0.0" />
     <PackageReference Include="BCrypt.Net-Next" Version="4.0.2" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="9.0.6" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="9.0.6" />
   </ItemGroup>
 
   <PropertyGroup>

--- a/conViver.Core/Entities/Votacao.cs
+++ b/conViver.Core/Entities/Votacao.cs
@@ -6,6 +6,8 @@ public class Votacao
     public Guid CondominioId { get; set; }
     public string Titulo { get; set; } = string.Empty;
     public string? Descricao { get; set; }
+    public string Assunto { get; set; } = string.Empty;
+    public DateTime CriadoEm { get; set; } = DateTime.UtcNow;
     public DateTime DataInicio { get; set; } = DateTime.UtcNow;
     public DateTime DataFim { get; set; }
     public bool Ativa { get; set; } = true;

--- a/conViver.Infrastructure/Payments/PaymentGatewayService.cs
+++ b/conViver.Infrastructure/Payments/PaymentGatewayService.cs
@@ -17,9 +17,7 @@ public class PaymentGatewayService : IFinanceiroService
     public Task RegistrarPagamentoAsync(Boleto boleto, decimal valor, CancellationToken cancellationToken = default)
     {
         _logger.LogInformation("Pagamento registrado para boleto {NossoNumero}", boleto.NossoNumero);
-        boleto.Status = BoletoStatus.Pago;
-        boleto.ValorPago = valor;
-        boleto.DataPagamento = DateTime.UtcNow;
+        boleto.RegistrarPagamento(valor, DateTime.UtcNow);
         return Task.CompletedTask;
     }
 }

--- a/conViver.Infrastructure/conViver.Infrastructure.csproj
+++ b/conViver.Infrastructure/conViver.Infrastructure.csproj
@@ -20,6 +20,9 @@
     <PackageReference Include="Serilog.Extensions.Logging" Version="9.0.2" />
     <PackageReference Include="Serilog.Settings.Configuration" Version="9.0.0" />
     <PackageReference Include="StackExchange.Redis" Version="2.8.41" />
+    <PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="7.0.1" />
+    <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="9.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Hosting" Version="9.0.0" />
   </ItemGroup>
 
   <PropertyGroup>


### PR DESCRIPTION
## Summary
- fix FinanceiroService and PaymentGatewayService to use domain methods
- support dependency injection and JWT bearer packages
- add missing properties to Votacao entity
- ensure infrastructure authentication packages are referenced

## Testing
- `dotnet build conViver.API/conViver.API.csproj --no-restore -c Release`
- `dotnet test conViver.Tests/conViver.Tests.csproj --no-build --verbosity minimal`

------
https://chatgpt.com/codex/tasks/task_e_6852db0f3730833281e67df7abf84704