### PR TITLE
Fix Boleto initialization in batch generation

### DIFF
--- a/conViver.Application/Services/FinanceiroService.cs
+++ b/conViver.Application/Services/FinanceiroService.cs
@@ -241,8 +241,7 @@ namespace conViver.Application.Services // Changed namespace to match convention
                     Id = Guid.NewGuid(),
                     UnidadeId = unidade.Id,
                     Valor = valorTotalLote, // Assuming the same total value for all units in this batch
-                    DataVencimento = dataVencimento,
-                    Status = BoletoStatus.Gerado // Default status
+                    DataVencimento = dataVencimento
                 };
                 novosBoletos.Add(boleto);
                 Console.WriteLine($"Boleto preparado para Unidade {unidade.Identificacao}, Valor: {boleto.Valor}, Vencimento: {boleto.DataVencimento:yyyy-MM-dd}");


### PR DESCRIPTION
## Summary
- adjust `GerarCobrancasEmLoteAsync` to no longer set `Status` explicitly
- build the solution to verify compilation

## Testing
- `dotnet build conViver.sln --no-restore`

------
https://chatgpt.com/codex/tasks/task_e_685312db7bc08332b45602471b4c8b93