### PR TITLE
Update local setup docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,7 +99,8 @@ dotnet ef database update --project src/Infrastructure
 
 3. Rodar API
 cd conViver.API
-dotnet run        # localhost:5000  (Swagger em /swagger)
+ASPNETCORE_ENVIRONMENT=Development dotnet run  # localhost:5000  (Swagger em /api/v1/swagger somente em Development)
+# /auth/signup é um POST – veja API_REFERENCE.md
 
 4. Front Web
 # Abrir um simple static server (ex. live-server)


### PR DESCRIPTION
## Summary
- document setting `ASPNETCORE_ENVIRONMENT=Development` when running the API
- note that Swagger is only in development and available at `/api/v1/swagger`
- remind that `/auth/signup` is a POST endpoint

## Testing
- `dotnet test conViver.Tests/conViver.Tests.csproj --verbosity minimal` *(fails: `CustomWebApplicationFactory<TProgram>.CreateHost` no suitable method found)*

------
https://chatgpt.com/codex/tasks/task_e_685328eea31c833298f58a42aff8e032