### PR TITLE
Fix API path base usage in JS

### DIFF
--- a/conViver.Web/js/apiClient.js
+++ b/conViver.Web/js/apiClient.js
@@ -1,4 +1,6 @@
-const API_BASE = '/api/v1';
+// Base path for the API. With app.UsePathBase("/api/v1") the
+// frontend must explicitly prefix requests with /api/v1.
+const API_BASE = '';
 
 /**
  * Custom error class for API requests.

--- a/conViver.Web/js/comunicacao.js
+++ b/conViver.Web/js/comunicacao.js
@@ -18,7 +18,7 @@ async function carregarAvisos() {
     container.innerHTML = '<p>Carregando...</p>'; // Local loading indicator
 
     try {
-        const resp = await apiClient.get('/app/avisos?page=1&size=10');
+        const resp = await apiClient.get('/api/v1/app/avisos?page=1&size=10');
         const avisos = resp.items || resp;
 
         container.innerHTML = ''; // Clear loading indicator

--- a/conViver.Web/js/dashboard.js
+++ b/conViver.Web/js/dashboard.js
@@ -238,7 +238,7 @@ document.addEventListener('DOMContentLoaded', async () => {
 
         try {
             console.log('Buscando dados do dashboard...');
-            const dados = await apiClient.get('/dashboard/geral');
+            const dados = await apiClient.get('/api/v1/dashboard/geral');
             console.log('Dados recebidos:', dados);
 
             // Clear local loading messages (optional, as global feedback is present)

--- a/conViver.Web/js/financeiro.js
+++ b/conViver.Web/js/financeiro.js
@@ -115,7 +115,7 @@ document.addEventListener('DOMContentLoaded', () => {
         const novaCobrancaDto = { unidadeId, valor, dataVencimento, descricao };
 
         try {
-            await apiClient.post('/financeiro/cobrancas', novaCobrancaDto);
+            await apiClient.post('/api/v1/financeiro/cobrancas', novaCobrancaDto);
             showGlobalFeedback('Cobrança emitida com sucesso!', 'success', 5000);
             closeModal();
             fetchAndRenderCobrancas(filtroStatusEl ? filtroStatusEl.value : '');
@@ -155,7 +155,7 @@ document.addEventListener('DOMContentLoaded', () => {
             };
 
             try {
-                const resultado = await apiClient.post('/financeiro/cobrancas/gerar-lote', requestBody);
+                const resultado = await apiClient.post('/api/v1/financeiro/cobrancas/gerar-lote', requestBody);
                 if (resultado.sucesso) {
                     showGlobalFeedback(resultado.mensagem || 'Lote gerado com sucesso!', 'success', 5000);
                     fetchAndRenderCobrancas(filtroStatusEl ? filtroStatusEl.value : '');
@@ -191,7 +191,7 @@ document.addEventListener('DOMContentLoaded', () => {
                 showGlobalFeedback('Processando...', 'info', 2000);
                 target.disabled = true;
                 try {
-                    const response = await apiClient.get(`/financeiro/cobrancas/${cobrancaId}/segunda-via`);
+                    const response = await apiClient.get(`/api/v1/financeiro/cobrancas/${cobrancaId}/segunda-via`);
                     if (response && response.url) {
                         window.open(response.url, '_blank');
                         showGlobalFeedback('Link da 2ª via aberto em nova aba.', 'success', 5000);
@@ -210,7 +210,7 @@ document.addEventListener('DOMContentLoaded', () => {
                 target.disabled = true;
                 try {
                     // Assuming PUT request for cancel, adjust if it's POST or DELETE
-                    const resultado = await apiClient.put(`/financeiro/cobrancas/${cobrancaId}/cancelar`, {});
+                    const resultado = await apiClient.put(`/api/v1/financeiro/cobrancas/${cobrancaId}/cancelar`, {});
                     if (resultado && resultado.sucesso) {
                         showGlobalFeedback(resultado.mensagem || 'Cobrança cancelada com sucesso!', 'success', 5000);
                         fetchAndRenderCobrancas(filtroStatusEl ? filtroStatusEl.value : '');
@@ -301,7 +301,7 @@ document.addEventListener('DOMContentLoaded', () => {
         if (!tbodyCobrancas) return;
         tbodyCobrancas.innerHTML = '<tr><td colspan="6" class="text-center">Carregando cobranças...</td></tr>';
 
-        let apiUrl = '/financeiro/cobrancas';
+        let apiUrl = '/api/v1/financeiro/cobrancas';
         if (status) {
             apiUrl += `?status=${encodeURIComponent(status)}`;
         }
@@ -327,7 +327,7 @@ document.addEventListener('DOMContentLoaded', () => {
         if (summaryPendentesEl) summaryPendentesEl.textContent = 'Carregando...';
 
         try {
-            const dashboardData = await apiClient.get('/financeiro/cobrancas/dashboard');
+            const dashboardData = await apiClient.get('/api/v1/financeiro/cobrancas/dashboard');
             renderDashboardFinanceiro(dashboardData);
         } catch (error) {
             console.error('Erro ao buscar dados do dashboard financeiro:', error);

--- a/conViver.Web/js/login.js
+++ b/conViver.Web/js/login.js
@@ -47,7 +47,7 @@ if (loginForm) {
         const password = passwordInput.value;
 
         try {
-            const response = await apiClient.post('/auth/login', { email, password });
+            const response = await apiClient.post('/api/v1/auth/login', { email, password });
             setToken(response.accessToken);
 
             showFeedback('Login bem-sucedido! Redirecionando...', 'success');

--- a/conViver.Web/js/portaria.js
+++ b/conViver.Web/js/portaria.js
@@ -23,7 +23,7 @@ async function carregarVisitantes() {
         const from = new Date(hoje.getFullYear(), hoje.getMonth(), hoje.getDate() - 7)
             .toISOString().slice(0,10);
         const to = hoje.toISOString().slice(0,10);
-        const visitas = await apiClient.get(`/syndic/visitantes?from=${from}&to=${to}`);
+        const visitas = await apiClient.get(`/api/v1/syndic/visitantes?from=${from}&to=${to}`);
 
         tbody.innerHTML = ''; // Clear loading indicator
         if (visitas && visitas.length > 0) {
@@ -55,7 +55,7 @@ async function carregarEncomendas() {
     tbody.innerHTML = '<tr><td colspan="3">Carregando...</td></tr>'; // Local loading indicator
 
     try {
-        const encomendas = await apiClient.get('/syndic/encomendas?status=recebida');
+        const encomendas = await apiClient.get('/api/v1/syndic/encomendas?status=recebida');
 
         tbody.innerHTML = ''; // Clear loading indicator
         if (encomendas && encomendas.length > 0) {

--- a/conViver.Web/js/reservas.js
+++ b/conViver.Web/js/reservas.js
@@ -27,7 +27,7 @@ async function carregarAgenda() {
     try {
         const now = new Date();
         const mes = now.toISOString().slice(0,7);
-        const reservas = await apiClient.get(`/app/reservas/agenda?mesAno=${mes}`);
+        const reservas = await apiClient.get(`/api/v1/app/reservas/agenda?mesAno=${mes}`);
 
         container.innerHTML = ''; // Clear loading indicator
         if (reservas && reservas.length > 0) {
@@ -69,7 +69,7 @@ async function criarReserva(evt) {
     if (submitButton) submitButton.disabled = true;
 
     try {
-        await apiClient.post('/app/reservas', { area, inicio, fim });
+        await apiClient.post('/api/v1/app/reservas', { area, inicio, fim });
         showGlobalFeedback('Reserva criada com sucesso!', 'success', 5000);
         form.reset();
         await carregarAgenda(); // Recarrega a agenda para mostrar a nova reserva

--- a/conViver.Web/wwwroot/js/apiClient.js
+++ b/conViver.Web/wwwroot/js/apiClient.js
@@ -1,4 +1,7 @@
-const API_BASE = '/api/v1';
+// Base path for the API. When the backend uses app.UsePathBase("/api/v1")
+// the frontend should include this prefix in each request instead of
+// relying on the client to append it.
+const API_BASE = '';
 
 export function getToken() {
     return localStorage.getItem('cv_token');

--- a/conViver.Web/wwwroot/js/comunicacao.js
+++ b/conViver.Web/wwwroot/js/comunicacao.js
@@ -6,7 +6,7 @@ document.addEventListener('DOMContentLoaded', async () => {
 
 async function carregarAvisos() {
     try {
-        const resp = await apiClient.get('/app/avisos?page=1&size=10');
+        const resp = await apiClient.get('/api/v1/app/avisos?page=1&size=10');
         const avisos = resp.items || resp;
         const container = document.querySelector('.js-avisos');
         container.innerHTML = '';

--- a/conViver.Web/wwwroot/js/dashboard.js
+++ b/conViver.Web/wwwroot/js/dashboard.js
@@ -2,7 +2,7 @@ import apiClient from './apiClient.js';
 
 document.addEventListener('DOMContentLoaded', async () => {
     try {
-        const metrics = await apiClient.get('/syndic/reports/dashboard');
+        const metrics = await apiClient.get('/api/v1/syndic/reports/dashboard');
         if (metrics.inadimplencia !== undefined) {
             const val = (metrics.inadimplencia * 100).toFixed(1) + '%';
             document.querySelector('.js-inadimplencia').textContent = val;

--- a/conViver.Web/wwwroot/js/financeiro.js
+++ b/conViver.Web/wwwroot/js/financeiro.js
@@ -2,7 +2,7 @@ import apiClient from './apiClient.js';
 
 document.addEventListener('DOMContentLoaded', async () => {
     try {
-        const boletos = await apiClient.get('/syndic/finance/boletos');
+        const boletos = await apiClient.get('/api/v1/syndic/finance/boletos');
         const tbody = document.querySelector('.js-boletos');
         tbody.innerHTML = '';
         boletos.forEach(b => {

--- a/conViver.Web/wwwroot/js/portaria.js
+++ b/conViver.Web/wwwroot/js/portaria.js
@@ -11,7 +11,7 @@ async function carregarVisitantes() {
         const from = new Date(hoje.getFullYear(), hoje.getMonth(), hoje.getDate() - 7)
             .toISOString().slice(0,10);
         const to = hoje.toISOString().slice(0,10);
-        const visitas = await apiClient.get(`/syndic/visitantes?from=${from}&to=${to}`);
+        const visitas = await apiClient.get(`/api/v1/syndic/visitantes?from=${from}&to=${to}`);
         const tbody = document.querySelector('.js-visitantes');
         tbody.innerHTML = '';
         visitas.forEach(v => {
@@ -26,7 +26,7 @@ async function carregarVisitantes() {
 
 async function carregarEncomendas() {
     try {
-        const encomendas = await apiClient.get('/syndic/encomendas?status=recebida');
+        const encomendas = await apiClient.get('/api/v1/syndic/encomendas?status=recebida');
         const tbody = document.querySelector('.js-encomendas');
         tbody.innerHTML = '';
         encomendas.forEach(e => {

--- a/conViver.Web/wwwroot/js/reservas.js
+++ b/conViver.Web/wwwroot/js/reservas.js
@@ -9,7 +9,7 @@ async function carregarAgenda() {
     try {
         const now = new Date();
         const mes = now.toISOString().slice(0,7);
-        const reservas = await apiClient.get(`/app/reservas/agenda?mesAno=${mes}`);
+        const reservas = await apiClient.get(`/api/v1/app/reservas/agenda?mesAno=${mes}`);
         const container = document.querySelector('.js-calendario');
         container.innerHTML = '';
         reservas.forEach(r => {
@@ -31,7 +31,7 @@ async function criarReserva(evt) {
     const inicio = `${data}T10:00:00`;
     const fim = `${data}T12:00:00`;
     try {
-        await apiClient.post('/app/reservas', { area: 'Area Comum', inicio, fim });
+        await apiClient.post('/api/v1/app/reservas', { area: 'Area Comum', inicio, fim });
         evt.target.reset();
         carregarAgenda();
     } catch(err) {


### PR DESCRIPTION
## Summary
- update `apiClient` to no longer prepend `/api/v1`
- prefix all fetch/AJAX paths with `/api/v1`

## Testing
- `dotnet test --no-build` *(fails: `dotnet: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_68535133daa88332bd58266690b3fb16