### PR TITLE
Fix duplicate DTO class

### DIFF
--- a/conViver.Application/conViver.Application.csproj
+++ b/conViver.Application/conViver.Application.csproj
@@ -5,6 +5,10 @@
   </ItemGroup>
 
   <ItemGroup>
+    <FrameworkReference Include="Microsoft.AspNetCore.App" />
+  </ItemGroup>
+
+  <ItemGroup>
     <PackageReference Include="FluentValidation" Version="12.0.0" />
     <PackageReference Include="FluentValidation.DependencyInjectionExtensions" Version="11.9.0" /> <!-- Check for latest compatible version with 12.0.0 or use same major -->
     <PackageReference Include="BCrypt.Net-Next" Version="4.0.2" />

--- a/conViver.Core/DTOs/CondominioDtos.cs
+++ b/conViver.Core/DTOs/CondominioDtos.cs
@@ -55,7 +55,7 @@ public class CondominioInputDto // Usado para Create e Update
     public bool Ativo { get; set; } = true;
 }
 
-public class CondominioDto // Para GetById e ListAll
+public class CondominioDetalhadoDto // Para GetById e ListAll
 {
     public Guid Id { get; set; }
     public string Nome { get; set; } = string.Empty;


### PR DESCRIPTION
## Summary
- rename `CondominioDto` in shared DTOs to avoid duplication
- allow application project to reference ASP.NET types

## Testing
- `dotnet build conViver.API/conViver.API.csproj --no-restore` *(fails: PrestadorService.cs(61,21): CS0266)*
- `dotnet test conViver.Tests/conViver.Tests.csproj --no-restore --no-build` *(fails: argument invalid)*

------
https://chatgpt.com/codex/tasks/task_e_6853722faaa08332830ff3be6943b213