### PR TITLE
Add launch config for dotnet watch run

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,17 @@
+{
+    "version": "0.2.0",
+    "configurations": [
+        {
+            "name": "Run conViver.API (dotnet watch run)",
+            "type": "coreclr",
+            "request": "launch",
+            "program": "dotnet",
+            "args": ["watch", "run"],
+            "cwd": "${workspaceFolder}/conViver.API",
+            "console": "integratedTerminal",
+            "env": {
+                "ASPNETCORE_ENVIRONMENT": "Development"
+            }
+        }
+    ]
+}

--- a/conViver.API/Properties/launchSettings.json
+++ b/conViver.API/Properties/launchSettings.json
@@ -14,7 +14,7 @@
       "dotnetRunMessages": true,
       "launchBrowser": true,
       "launchUrl": "swagger",
-      "applicationUrl": "http://localhost:5215",
+      "applicationUrl": "http://localhost:5000",
       "environmentVariables": {
         "ASPNETCORE_ENVIRONMENT": "Development"
       }


### PR DESCRIPTION
## Summary
- enable running API via VS Code launch config
- set development profile port to 5000

## Testing
- `dotnet build conViver.sln --no-restore`
- `dotnet test conViver.Tests/conViver.Tests.csproj` *(fails: CS0266 / CS1061)*

------
https://chatgpt.com/codex/tasks/task_e_685375961c408332b032bb58f7051140