### PR TITLE
Implement queue and audit log

### DIFF
--- a/conViver.API/Controllers/AvisosController.cs
+++ b/conViver.API/Controllers/AvisosController.cs
@@ -45,6 +45,19 @@ public class AvisosController : ControllerBase
         return Ok(paged);
     }
 
+    [HttpPost("/api/v1/app/avisos/{id:guid}/ler")]
+    [Authorize(Roles = "Sindico,Condomino,Inquilino")]
+    public async Task<IActionResult> RegistrarLeitura(Guid id, [FromHeader(Name="X-Device-Id")] string? deviceId)
+    {
+        var userIdClaim = User.FindFirstValue(ClaimTypes.NameIdentifier);
+        if (string.IsNullOrEmpty(userIdClaim) || !Guid.TryParse(userIdClaim, out Guid userId))
+            return Unauthorized();
+
+        string ip = HttpContext.Connection.RemoteIpAddress?.ToString() ?? string.Empty;
+        await _avisos.RegistrarLeituraAsync(id, userId, ip, deviceId);
+        return Ok();
+    }
+
     /// <summary>
     /// Cria um novo aviso para o condomínio.
     /// </summary>

--- a/conViver.API/Controllers/VotacoesController.cs
+++ b/conViver.API/Controllers/VotacoesController.cs
@@ -138,7 +138,7 @@ public class VotacoesController : ControllerBase
 
         try
         {
-            var sucesso = await _votacaoService.RegistrarVotoAsync(id, votoInput.OpcaoId, condominioId, userId);
+            var sucesso = await _votacaoService.RegistrarVotoAsync(id, votoInput.OpcaoId, condominioId, userId, votoInput.UnidadeId, HttpContext.Connection.RemoteIpAddress?.ToString(), votoInput.DeviceId);
             if (sucesso)
             {
                 return Ok("Voto registrado com sucesso.");

--- a/conViver.Application/Services/VotacaoService.cs
+++ b/conViver.Application/Services/VotacaoService.cs
@@ -104,7 +104,7 @@ public class VotacaoService
         };
     }
 
-    public async Task<bool> RegistrarVotoAsync(Guid votacaoId, Guid opcaoId, Guid condominioId, Guid usuarioId, CancellationToken ct = default)
+    public async Task<bool> RegistrarVotoAsync(Guid votacaoId, Guid opcaoId, Guid condominioId, Guid usuarioId, Guid unidadeId, string? ip, string? deviceId, CancellationToken ct = default)
     {
         // Usar FirstOrDefaultAsync para poder verificar se a votação ou opção existem
         var votacao = await _votacoes.Query()
@@ -137,7 +137,8 @@ public class VotacaoService
             return false;
         }
 
-        bool jaVotou = votacao.Opcoes.SelectMany(o => o.VotosRecebidos).Any(vr => vr.UsuarioId == usuarioId);
+        bool jaVotou = votacao.Opcoes.SelectMany(o => o.VotosRecebidos)
+            .Any(vr => vr.UsuarioId == usuarioId || vr.UnidadeId == unidadeId);
         if (jaVotou)
         {
             throw new InvalidOperationException("Usuário já votou nesta votação.");
@@ -148,6 +149,9 @@ public class VotacaoService
             Id = Guid.NewGuid(),
             OpcaoVotacaoId = opcaoId,
             UsuarioId = usuarioId,
+            UnidadeId = unidadeId,
+            Ip = ip,
+            DeviceId = deviceId,
             DataVoto = DateTime.UtcNow
             // A OpcaoVotacao navigation property será ligada pelo EF Core se necessário,
             // mas adicionar à lista OpcaoVotacao.VotosRecebidos é mais direto.

--- a/conViver.Core/DTOs/VotacaoDtos.cs
+++ b/conViver.Core/DTOs/VotacaoDtos.cs
@@ -62,4 +62,6 @@ public class VotoInputDto
 {
     [Required(ErrorMessage = "O ID da opção é obrigatório.")]
     public Guid OpcaoId { get; set; }
+    public Guid UnidadeId { get; set; }
+    public string? DeviceId { get; set; }
 }

--- a/conViver.Core/Entities/AvisoLeitura.cs
+++ b/conViver.Core/Entities/AvisoLeitura.cs
@@ -1,0 +1,11 @@
+namespace conViver.Core.Entities;
+
+public class AvisoLeitura
+{
+    public Guid Id { get; set; }
+    public Guid AvisoId { get; set; }
+    public Guid UsuarioId { get; set; }
+    public DateTime LidoEm { get; set; } = DateTime.UtcNow;
+    public string? Ip { get; set; }
+    public string? DeviceId { get; set; }
+}

--- a/conViver.Core/Entities/LogAuditoria.cs
+++ b/conViver.Core/Entities/LogAuditoria.cs
@@ -1,0 +1,13 @@
+namespace conViver.Core.Entities;
+
+public class LogAuditoria
+{
+    public Guid Id { get; set; }
+    public Guid? UsuarioId { get; set; }
+    public string Acao { get; set; } = string.Empty;
+    public string Entidade { get; set; } = string.Empty;
+    public Guid? EntityId { get; set; }
+    public string? Detalhes { get; set; }
+    public Guid? TraceId { get; set; }
+    public DateTime CriadoEm { get; set; } = DateTime.UtcNow;
+}

--- a/conViver.Core/Entities/VotoRegistrado.cs
+++ b/conViver.Core/Entities/VotoRegistrado.cs
@@ -8,5 +8,8 @@ public class VotoRegistrado
     public Guid OpcaoVotacaoId { get; set; } // Foreign key para OpcaoVotacao
     public OpcaoVotacao? OpcaoVotacao { get; set; } // Navigation property
     public Guid UsuarioId { get; set; } // Id do usuário que votou
+    public Guid? UnidadeId { get; set; }
+    public string? Ip { get; set; }
+    public string? DeviceId { get; set; }
     public DateTime DataVoto { get; set; } = DateTime.UtcNow;
 }

--- a/conViver.Core/Interfaces/IAuditService.cs
+++ b/conViver.Core/Interfaces/IAuditService.cs
@@ -1,0 +1,10 @@
+using conViver.Core.Entities;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace conViver.Core.Interfaces;
+
+public interface IAuditService
+{
+    Task RegistrarAsync(LogAuditoria log, CancellationToken ct = default);
+}

--- a/conViver.Core/Notifications/INotificationQueue.cs
+++ b/conViver.Core/Notifications/INotificationQueue.cs
@@ -1,0 +1,9 @@
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace conViver.Core.Notifications;
+
+public interface INotificationQueue
+{
+    Task QueueAsync(NotificationMessage message, CancellationToken ct = default);
+}

--- a/conViver.Core/Notifications/INotificationSender.cs
+++ b/conViver.Core/Notifications/INotificationSender.cs
@@ -1,0 +1,9 @@
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace conViver.Core.Notifications;
+
+public interface INotificationSender
+{
+    Task SendAsync(NotificationMessage message, CancellationToken ct = default);
+}

--- a/conViver.Core/Notifications/NotificationMessage.cs
+++ b/conViver.Core/Notifications/NotificationMessage.cs
@@ -1,0 +1,3 @@
+namespace conViver.Core.Notifications;
+
+public record NotificationMessage(string Tipo, Guid? UsuarioId, string Titulo, string Corpo);

--- a/conViver.Infrastructure/Data/Contexts/ConViverDbContext.cs
+++ b/conViver.Infrastructure/Data/Contexts/ConViverDbContext.cs
@@ -27,6 +27,8 @@ public class ConViverDbContext : DbContext
     public DbSet<VotoRegistrado> VotosRegistrados => Set<VotoRegistrado>();
     public DbSet<Chamado> Chamados => Set<Chamado>();
     public DbSet<AvaliacaoPrestador> AvaliacoesPrestadores { get; set; } = null!; // Adicionado DbSet para AvaliacaoPrestador
+    public DbSet<AvisoLeitura> AvisosLidos => Set<AvisoLeitura>();
+    public DbSet<LogAuditoria> LogsAuditoria => Set<LogAuditoria>();
 
     protected override void OnModelCreating(ModelBuilder modelBuilder)
     {

--- a/conViver.Infrastructure/Data/Repositories/AuditLogRepository.cs
+++ b/conViver.Infrastructure/Data/Repositories/AuditLogRepository.cs
@@ -1,0 +1,18 @@
+using System.Threading;
+using System.Threading.Tasks;
+using conViver.Core.Entities;
+using conViver.Core.Interfaces;
+using conViver.Infrastructure.Data.Contexts;
+
+namespace conViver.Infrastructure.Data.Repositories;
+
+public class AuditLogRepository : Repository<LogAuditoria>, IAuditService
+{
+    public AuditLogRepository(ConViverDbContext context) : base(context) { }
+
+    public Task RegistrarAsync(LogAuditoria log, CancellationToken ct = default)
+    {
+        Db.Add(log);
+        return _context.SaveChangesAsync(ct);
+    }
+}

--- a/conViver.Infrastructure/DependencyInjection.cs
+++ b/conViver.Infrastructure/DependencyInjection.cs
@@ -6,6 +6,7 @@ using conViver.Infrastructure.Data.Contexts;
 using conViver.Infrastructure.Data.Repositories;
 using conViver.Infrastructure.Notifications;
 using conViver.Infrastructure.Payments;
+using conViver.Core.Notifications;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
@@ -37,6 +38,10 @@ public static class DependencyInjection
         services.AddSingleton<RedisCacheService>();
 
         services.AddScoped<INotificacaoService, NotificationService>();
+        services.AddSingleton<INotificationSender, NotificationService>();
+        services.AddSingleton<INotificationQueue, NotificationQueue>();
+        services.AddHostedService<NotificationQueue>(sp => (NotificationQueue)sp.GetRequiredService<INotificationQueue>());
+        services.AddScoped<IAuditService, AuditLogRepository>();
         services.AddScoped<IFinanceiroService, PaymentGatewayService>();
 
         services.AddScoped(typeof(IRepository<>), typeof(Repository<>));

--- a/conViver.Infrastructure/Notifications/NotificationQueue.cs
+++ b/conViver.Infrastructure/Notifications/NotificationQueue.cs
@@ -1,0 +1,31 @@
+using System.Threading;
+using System.Threading.Channels;
+using System.Threading.Tasks;
+using conViver.Core.Notifications;
+using Microsoft.Extensions.Hosting;
+
+namespace conViver.Infrastructure.Notifications;
+
+public class NotificationQueue : BackgroundService, INotificationQueue
+{
+    private readonly Channel<NotificationMessage> _channel = Channel.CreateUnbounded<NotificationMessage>();
+    private readonly INotificationSender _sender;
+
+    public NotificationQueue(INotificationSender sender)
+    {
+        _sender = sender;
+    }
+
+    public Task QueueAsync(NotificationMessage message, CancellationToken ct = default)
+    {
+        return _channel.Writer.WriteAsync(message, ct).AsTask();
+    }
+
+    protected override async Task ExecuteAsync(CancellationToken stoppingToken)
+    {
+        await foreach (var msg in _channel.Reader.ReadAllAsync(stoppingToken))
+        {
+            await _sender.SendAsync(msg, stoppingToken);
+        }
+    }
+}

--- a/conViver.Infrastructure/Notifications/NotificationService.cs
+++ b/conViver.Infrastructure/Notifications/NotificationService.cs
@@ -5,9 +5,11 @@ using conViver.Core.Enums;
 using conViver.Core.Interfaces;
 // Potentially add: using Microsoft.Extensions.Logging; if you want to use ILogger
 
+using conViver.Core.Notifications;
+
 namespace conViver.Infrastructure.Notifications
 {
-    public class NotificationService : INotificacaoService
+    public class NotificationService : INotificacaoService, INotificationSender
     {
         // Example: Optional ILogger for more structured logging
         // private readonly ILogger<NotificationService> _logger;
@@ -66,6 +68,12 @@ namespace conViver.Infrastructure.Notifications
             // This is a more complex scenario.
             string mensagem = $"[ADMIN NOTIFICACAO] CONFLITO DE RESERVA: Nova tentativa ({novaTentativa.Inicio}-{novaTentativa.Fim} por Usuário {novaTentativa.UsuarioId}) para Espaço {novaTentativa.EspacoComumId} conflita com Reserva existente ID {reservaConflitante.Id}.";
             Console.WriteLine(mensagem);
+            return Task.CompletedTask;
+        }
+
+        public Task SendAsync(NotificationMessage message, CancellationToken ct = default)
+        {
+            Console.WriteLine($"[QUEUE] Tipo:{message.Tipo} Usuario:{message.UsuarioId} {message.Titulo} - {message.Corpo}");
             return Task.CompletedTask;
         }
     }


### PR DESCRIPTION
## Summary
- add notification queue and audit log infrastructure
- log notice reads and enforce single vote per unit
- extend vote API with unit info
- add engagement tracking for notice views

## Testing
- `dotnet build conViver.sln -c Release`
- `dotnet test conViver.Tests/conViver.Tests.csproj` *(fails: 'Unidade' no member 'Nome', 'OrdemServico' missing fields)*

------
https://chatgpt.com/codex/tasks/task_e_685447026a3c8332afad67685262694e