### PR TITLE
Fix: Resolve UsuarioService dependency injection

### DIFF
--- a/conViver.Application/DependencyInjection.cs
+++ b/conViver.Application/DependencyInjection.cs
@@ -14,6 +14,7 @@ public static class DependencyInjection
     {
         services.AddTransient<CondominioService>();
         services.AddTransient<IUsuarioService, UsuarioService>();
+        services.AddTransient<UsuarioService>();
         services.AddTransient<FinanceiroService>();
         services.AddTransient<ReservaService>();
         services.AddTransient<OrdemServicoService>();


### PR DESCRIPTION
I added a direct transient registration for the concrete UsuarioService type in DependencyInjection.cs to allow UsuariosController to resolve it. This addresses the 'Unable to resolve service' error during login attempts.