### PR TITLE
Fix: Apply database migrations on startup

### DIFF
--- a/conViver.API/Program.cs
+++ b/conViver.API/Program.cs
@@ -102,6 +102,7 @@ using (var scope = app.Services.CreateScope())
 {
     var db = scope.ServiceProvider.GetRequiredService<ConViverDbContext>();
     // db.Database.EnsureCreated(); // Commented out to allow migrations to handle schema creation
+    db.Database.Migrate();
     DataSeeder.Seed(db);
 }
 


### PR DESCRIPTION
This commit addresses an issue where the application would fail on startup due to a 'no such table' SQLite error. The error occurred because database migrations were not being applied before the data seeder attempted to access the database.

The fix involves adding a call to `db.Database.Migrate()` in `Program.cs` immediately before the `DataSeeder.Seed(db)` call. This ensures that any pending Entity Framework Core migrations are applied when the application starts, creating or updating the database schema as needed before any data seeding operations occur.