### PR TITLE
Fix: Apply DB migrations at startup and add missing using directive

### DIFF
--- a/conViver.API/Program.cs
+++ b/conViver.API/Program.cs
@@ -4,6 +4,7 @@ using conViver.Infrastructure;
 using conViver.Infrastructure.Data.Contexts;
 using Microsoft.OpenApi.Models;
 using Microsoft.AspNetCore.Authentication.JwtBearer;
+using Microsoft.EntityFrameworkCore;
 using Microsoft.IdentityModel.Tokens;
 using conViver.Application.Services; // Moved here
 


### PR DESCRIPTION
This commit resolves two issues:

1.  Ensures database migrations are applied on application startup by adding `db.Database.Migrate()` in `Program.cs` before data seeding. This prevents 'no such table' errors when the seeder runs.
2.  Adds the `using Microsoft.EntityFrameworkCore;` directive to `Program.cs`. This was necessary to resolve a compilation error (CS1061) as `Migrate()` is an extension method and requires this namespace to be in scope.