### PR TITLE
Fix seeding order for sample user

### DIFF
--- a/conViver.Infrastructure/Data/Contexts/DataSeeder.cs
+++ b/conViver.Infrastructure/Data/Contexts/DataSeeder.cs
@@ -11,13 +11,49 @@ public static class DataSeeder
     {
         if (!db.Usuarios.Any())
         {
+            // Create a sample Condominio if none exists
+            var condominio = db.Condominios.FirstOrDefault();
+            if (condominio == null)
+            {
+                condominio = new Condominio
+                {
+                    Id = Guid.NewGuid(),
+                    Nome = "Condomínio Teste",
+                    Endereco = new conViver.Core.ValueObjects.Endereco
+                    {
+                        Logradouro = "Rua de Teste",
+                        Numero = "123",
+                        Bairro = "Centro",
+                        Cidade = "Testlândia",
+                        Uf = "TS",
+                        Cep = "00000-000"
+                    }
+                };
+                db.Condominios.Add(condominio);
+                db.SaveChanges();
+            }
+
+            // Create a sample Unidade linked to the Condominio
+            var unidade = new Unidade
+            {
+                Id = Guid.NewGuid(),
+                CondominioId = condominio.Id,
+                Identificacao = "Apto 101",
+                FracaoIdeal = 1,
+                Tipo = "Residencial"
+            };
+            db.Unidades.Add(unidade);
+            db.SaveChanges();
+
+            // Now create the admin user linked to the Unidade
             var user = new Usuario
             {
                 Id = Guid.NewGuid(),
                 Nome = "Usuário Teste",
                 Email = "admin@conviver.local",
                 SenhaHash = BCrypt.Net.BCrypt.HashPassword("admin123"),
-                Perfil = PerfilUsuario.Administrador
+                Perfil = PerfilUsuario.Administrador,
+                UnidadeId = unidade.Id
             };
             db.Usuarios.Add(user);
             db.SaveChanges();


### PR DESCRIPTION
## Summary
- seed Condominio and Unidade before Usuario to satisfy FK

## Testing
- `dotnet build conViver.Tests/conViver.Tests.csproj --no-restore`
- `dotnet test conViver.Tests/conViver.Tests.csproj --no-build --no-restore` *(fails: 'Program' is inaccessible due to its protection level)*

------
https://chatgpt.com/codex/tasks/task_e_68547af92c5c833294f27c439feaa80e