### PR TITLE
Fix: Use UpdateAsync in UsuarioService and update tests

### DIFF
--- a/conViver.Application/Services/UsuarioService.cs
+++ b/conViver.Application/Services/UsuarioService.cs
@@ -90,7 +90,7 @@ public class UsuarioService : IUsuarioService
             usuario.PasswordResetTokenExpiry = DateTime.UtcNow.AddHours(1); // Token valid for 1 hour
 
             // Update the user in the repository
-            _usuarioRepository.Update(usuario); // Assuming IRepository has an Update method
+            await _usuarioRepository.UpdateAsync(usuario, cancellationToken); // Assuming IRepository has an UpdateAsync method
             await _usuarioRepository.SaveChangesAsync(cancellationToken);
 
             // Simulate sending an email
@@ -117,7 +117,7 @@ public class UsuarioService : IUsuarioService
         usuario.PasswordResetTokenExpiry = null;
         usuario.UpdatedAt = DateTime.UtcNow;
 
-        _usuarioRepository.Update(usuario);
+        await _usuarioRepository.UpdateAsync(usuario, cancellationToken);
         await _usuarioRepository.SaveChangesAsync(cancellationToken);
 
         return true;


### PR DESCRIPTION
This commit corrects a compilation error in UsuarioService that occurred because of an attempt to call a synchronous `Update` method on the IRepository<Usuario> interface, which expects an asynchronous `UpdateAsync`.

Changes:
- Modified `UsuarioService.SolicitarResetSenhaAsync` and `UsuarioService.ResetarSenhaAsync` to correctly call `await _usuarioRepository.UpdateAsync(user, cancellationToken)`.
- Updated `UsuarioServiceTests.cs` to reflect these changes by mocking and verifying `UpdateAsync` instead of `Update`.

This ensures that user entity updates are handled asynchronously, aligning with the repository's interface and preventing the previous build failure.