### PR TITLE
Fix DB mismatch by adding migration

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,6 +99,7 @@ dotnet restore
 docker run -d --name pgconviver -e POSTGRES_PASSWORD=devpass -p 5432:5432 postgres:16
 # Aplique as migrations (SQLite ou PostgreSQL)
 dotnet ef database update --project src/conViver.Infrastructure
+# (reexecute sempre que fizer pull para aplicar novas migrations)
 
 3. Rodar API
 cd src/conViver.API

--- a/conViver.Infrastructure/Migrations/20250619223204_AddPasswordResetFields.Designer.cs
+++ b/conViver.Infrastructure/Migrations/20250619223204_AddPasswordResetFields.Designer.cs
@@ -2,6 +2,7 @@
 using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using conViver.Infrastructure.Data.Contexts;
 
@@ -10,9 +11,11 @@ using conViver.Infrastructure.Data.Contexts;
 namespace conViver.Infrastructure.Migrations
 {
     [DbContext(typeof(ConViverDbContext))]
-    partial class ConViverDbContextModelSnapshot : ModelSnapshot
+    [Migration("20250619223204_AddPasswordResetFields")]
+    partial class AddPasswordResetFields
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder.HasAnnotation("ProductVersion", "8.0.6");

--- a/conViver.Infrastructure/Migrations/20250619223204_AddPasswordResetFields.cs
+++ b/conViver.Infrastructure/Migrations/20250619223204_AddPasswordResetFields.cs
@@ -1,0 +1,39 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace conViver.Infrastructure.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddPasswordResetFields : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<string>(
+                name: "PasswordResetToken",
+                table: "Usuarios",
+                type: "TEXT",
+                nullable: true);
+
+            migrationBuilder.AddColumn<DateTime>(
+                name: "PasswordResetTokenExpiry",
+                table: "Usuarios",
+                type: "TEXT",
+                nullable: true);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "PasswordResetToken",
+                table: "Usuarios");
+
+            migrationBuilder.DropColumn(
+                name: "PasswordResetTokenExpiry",
+                table: "Usuarios");
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add migration to include password reset fields in Usuario
- note in README to rerun `dotnet ef database update` after pulling

## Testing
- `dotnet build conViver.API/conViver.API.csproj -c Release`

------
https://chatgpt.com/codex/tasks/task_e_68548f63ea18833289502f422e97f6e6