### PR TITLE
Fix default user seeding

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ conViver/
 
 > Com Docker (`docker compose up -d`) você já sobe **PostgreSQL, Redis e API** num tapa.
 > Para desenvolvimento rápido, a API suporta **SQLite** (arquivo `conviver.db`).
-> Rode `dotnet ef database update --project src/conViver.Infrastructure` antes de `dotnet run` para criar o banco e popular o usuário de teste (`teste@conviver.local` / `123456`).
+> Rode `dotnet ef database update --project src/conViver.Infrastructure` antes de `dotnet run` para criar o banco e popular usuários de exemplo (`admin@conviver.local` / `admin123` e `teste@conviver.local` / `123456`).
 
 ### 1. Clone & restaure pacotes
 ```bash
@@ -135,7 +135,7 @@ dotnet build -t:Run -f net8.0-android
 | `WEB_API_BASE_URL`            | Define a URL base da API para o cliente web. Valor em `src/conViver.Web/js/config.js` (ex: `window.APP_CONFIG.API_BASE_URL`).                | `http://localhost:5000/api/v1`                            |
 
 `src/conViver.API/appsettings.Development.json` possui defaults seguros para desenvolvimento.
-> Usuário de teste: `teste@conviver.local` / `123456` (verificar se ainda válido após migrações e seeders).
+> Usuários de exemplo: `admin@conviver.local` / `admin123` (administrador) e `teste@conviver.local` / `123456` (morador). Verifique se ainda estão válidos após migrações e seeders.
 
 <!-- Seção Removida: Scripts & Automação
 ## Scripts & Automação

--- a/conViver.Infrastructure/Data/Contexts/DataSeeder.cs
+++ b/conViver.Infrastructure/Data/Contexts/DataSeeder.cs
@@ -46,16 +46,29 @@ public static class DataSeeder
             db.SaveChanges();
 
             // Now create the admin user linked to the Unidade
-            var user = new Usuario
+            var adminUser = new Usuario
             {
                 Id = Guid.NewGuid(),
-                Nome = "Usuário Teste",
+                Nome = "Usuário Administrador",
                 Email = "admin@conviver.local",
                 SenhaHash = BCrypt.Net.BCrypt.HashPassword("admin123"),
                 Perfil = PerfilUsuario.Administrador,
                 UnidadeId = unidade.Id
             };
-            db.Usuarios.Add(user);
+            db.Usuarios.Add(adminUser);
+
+            // Additional regular test user as referenced in README
+            var testUser = new Usuario
+            {
+                Id = Guid.NewGuid(),
+                Nome = "Usuário de Teste",
+                Email = "teste@conviver.local",
+                SenhaHash = BCrypt.Net.BCrypt.HashPassword("123456"),
+                Perfil = PerfilUsuario.Morador,
+                UnidadeId = unidade.Id
+            };
+            db.Usuarios.Add(testUser);
+
             db.SaveChanges();
         }
     }


### PR DESCRIPTION
## Summary
- seed both admin and test users
- clarify credentials in README

## Testing
- `dotnet test conViver.Tests/conViver.Tests.csproj -v minimal` *(fails: Program is inaccessible)*

------
https://chatgpt.com/codex/tasks/task_e_685495392fa48332b453dbd78659c36f