### PR TITLE
feat: Implement redesigned Digital Wall with unified feed

### DIFF
--- a/conViver.API/Controllers/FeedController.cs
+++ b/conViver.API/Controllers/FeedController.cs
@@ -1,0 +1,69 @@
+using conViver.Application.Services;
+using conViver.Core.DTOs;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Security.Claims;
+using System.Threading.Tasks;
+
+namespace conViver.API.Controllers
+{
+    [ApiController]
+    [Route("/api/v1/feed")]
+    [Authorize(Roles = "Syndic,Resident,Tenant")] // Using roles consistent with other controllers
+    public class FeedController : ControllerBase
+    {
+        private readonly FeedService _feedService;
+
+        public FeedController(FeedService feedService)
+        {
+            _feedService = feedService;
+        }
+
+        [HttpGet]
+        public async Task<ActionResult<IEnumerable<FeedItemDto>>> GetFeedItemsAsync(
+            [FromQuery] int pageNumber = 1,
+            [FromQuery] int pageSize = 10,
+            [FromQuery] string? categoria = null,
+            [FromQuery] DateTime? periodoInicio = null,
+            [FromQuery] DateTime? periodoFim = null)
+        {
+            var userIdClaim = User.FindFirstValue(ClaimTypes.NameIdentifier);
+            var condominioIdClaim = User.FindFirstValue("condominioId");
+
+            if (string.IsNullOrEmpty(userIdClaim) || !Guid.TryParse(userIdClaim, out Guid userId) ||
+                string.IsNullOrEmpty(condominioIdClaim) || !Guid.TryParse(condominioIdClaim, out Guid condominioId))
+            {
+                return Unauthorized("Informações de usuário ou condomínio inválidas no token.");
+            }
+
+            // Basic validation for pagination parameters
+            if (pageNumber < 1) pageNumber = 1;
+            if (pageSize < 1) pageSize = 1;
+            if (pageSize > 100) pageSize = 100; // Max page size limit
+
+            try
+            {
+                var feedItems = await _feedService.GetFeedAsync(condominioId, userId, pageNumber, pageSize, categoria, periodoInicio, periodoFim, HttpContext.RequestAborted);
+
+                // If feedItems is null or empty, returning Ok with an empty list is standard.
+                // The frontend can then decide how to display "no items found".
+                return Ok(feedItems ?? Enumerable.Empty<FeedItemDto>());
+            }
+            catch (ArgumentException ex) // Catch specific, known exceptions
+            {
+                // Log the exception (e.g., using ILogger)
+                // logger.LogWarning(ex, "Argument exception while fetching feed items.");
+                return BadRequest(new { message = ex.Message });
+            }
+            catch (Exception ex) // Catch-all for unexpected errors
+            {
+                // Log the exception (e.g., using ILogger)
+                // logger.LogError(ex, "Unexpected error while fetching feed items.");
+                return StatusCode(500, "Ocorreu um erro ao processar sua solicitação.");
+            }
+        }
+    }
+}

--- a/conViver.API/Controllers/OcorrenciasController.cs
+++ b/conViver.API/Controllers/OcorrenciasController.cs
@@ -1,0 +1,124 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Security.Claims;
+using System.Threading.Tasks;
+using conViver.Application.Services;
+using conViver.Core.DTOs;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+
+namespace conViver.API.Controllers
+{
+    [ApiController]
+    public class OcorrenciasController : ControllerBase
+    {
+        private readonly OcorrenciaService _ocorrenciaService;
+
+        public OcorrenciasController(OcorrenciaService ocorrenciaService)
+        {
+            _ocorrenciaService = ocorrenciaService;
+        }
+
+        private Guid GetUsuarioIdFromClaims() => Guid.Parse(User.FindFirstValue(ClaimTypes.NameIdentifier) ?? throw new UnauthorizedAccessException("User ID not found in token."));
+        private Guid GetCondominioIdFromClaims() => Guid.Parse(User.FindFirstValue("condominioId") ?? throw new UnauthorizedAccessException("Condominio ID not found in token."));
+        private bool IsSyndic() => User.IsInRole("Syndic") || User.IsInRole("SubSyndic"); // Assuming roles are set up
+
+        // POST /api/v1/app/ocorrencias
+        [HttpPost("/api/v1/app/ocorrencias")]
+        [Authorize(Roles = "Resident,Syndic,SubSyndic")] // Any authenticated user in a condominio can register
+        public async Task<IActionResult> RegistrarOcorrencia([FromBody] OcorrenciaInputDto input)
+        {
+            var usuarioId = GetUsuarioIdFromClaims();
+            var condominioId = GetCondominioIdFromClaims();
+
+            var ocorrencia = await _ocorrenciaService.RegistrarOcorrenciaAsync(condominioId, usuarioId, input);
+            var dto = new OcorrenciaDto // Manual mapping here or use the service's mapper if preferred
+            {
+                Id = ocorrencia.Id,
+                CondominioId = ocorrencia.CondominioId,
+                UnidadeId = ocorrencia.UnidadeId,
+                UsuarioId = ocorrencia.UsuarioId,
+                Titulo = ocorrencia.Titulo,
+                Descricao = ocorrencia.Descricao,
+                Fotos = ocorrencia.Fotos,
+                Status = ocorrencia.Status,
+                Tipo = ocorrencia.Tipo,
+                DataOcorrencia = ocorrencia.DataOcorrencia,
+                CreatedAt = ocorrencia.CreatedAt,
+                UpdatedAt = ocorrencia.UpdatedAt
+            };
+            return CreatedAtAction(nameof(ObterOcorrenciaPorIdApp), new { id = ocorrencia.Id }, dto);
+        }
+
+        // GET /api/v1/app/ocorrencias
+        [HttpGet("/api/v1/app/ocorrencias")]
+        [Authorize(Roles = "Resident,Syndic,SubSyndic")]
+        public async Task<IActionResult> ListarMinhasOcorrencias([FromQuery] string? status, [FromQuery] string? tipo)
+        {
+            var usuarioId = GetUsuarioIdFromClaims();
+            var condominioId = GetCondominioIdFromClaims();
+            var ocorrencias = await _ocorrenciaService.ListarOcorrenciasPorUsuarioAsync(condominioId, usuarioId, status, tipo);
+            return Ok(ocorrencias);
+        }
+
+        // GET /api/v1/app/ocorrencias/{id}
+        [HttpGet("/api/v1/app/ocorrencias/{id}")]
+        [Authorize(Roles = "Resident,Syndic,SubSyndic")]
+        public async Task<IActionResult> ObterOcorrenciaPorIdApp(Guid id)
+        {
+            var usuarioId = GetUsuarioIdFromClaims();
+            var condominioId = GetCondominioIdFromClaims();
+            var ocorrencia = await _ocorrenciaService.ObterOcorrenciaPorIdAsync(id, condominioId, usuarioId, IsSyndic()); // Pass IsSyndic for broader access if manager
+
+            if (ocorrencia == null)
+            {
+                return NotFound();
+            }
+            return Ok(ocorrencia);
+        }
+
+        // GET /api/v1/syndic/ocorrencias
+        [HttpGet("/api/v1/syndic/ocorrencias")]
+        [Authorize(Roles = "Syndic,SubSyndic")] // Only management roles
+        public async Task<IActionResult> ListarOcorrenciasGestao([FromQuery] string? status, [FromQuery] string? tipo)
+        {
+            var condominioId = GetCondominioIdFromClaims();
+            var ocorrencias = await _ocorrenciaService.ListarOcorrenciasParaGestaoAsync(condominioId, status, tipo);
+            return Ok(ocorrencias);
+        }
+
+        // GET /api/v1/syndic/ocorrencias/{id}
+        [HttpGet("/api/v1/syndic/ocorrencias/{id}")]
+        [Authorize(Roles = "Syndic,SubSyndic")]
+        public async Task<IActionResult> ObterOcorrenciaPorIdGestao(Guid id)
+        {
+            var condominioId = GetCondominioIdFromClaims();
+            var usuarioId = GetUsuarioIdFromClaims(); // Needed for the service method, even if primarily for gestor
+            var ocorrencia = await _ocorrenciaService.ObterOcorrenciaPorIdAsync(id, condominioId, usuarioId, true); // isGestor = true
+
+            if (ocorrencia == null)
+            {
+                return NotFound();
+            }
+            return Ok(ocorrencia);
+        }
+
+        // PUT /api/v1/syndic/ocorrencias/{id}
+        [HttpPut("/api/v1/syndic/ocorrencias/{id}")]
+        [Authorize(Roles = "Syndic,SubSyndic")]
+        public async Task<IActionResult> AtualizarOcorrencia(Guid id, [FromBody] OcorrenciaUpdateDto updateDto)
+        {
+            var condominioId = GetCondominioIdFromClaims();
+            var gestorUserId = GetUsuarioIdFromClaims();
+
+            var ocorrencia = await _ocorrenciaService.AtualizarOcorrenciaAsync(id, condominioId, gestorUserId, updateDto);
+
+            if (ocorrencia == null)
+            {
+                return NotFound();
+            }
+            return Ok(ocorrencia);
+        }
+    }
+}

--- a/conViver.Application/Services/FeedService.cs
+++ b/conViver.Application/Services/FeedService.cs
@@ -1,0 +1,477 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using conViver.Core.DTOs;
+using conViver.Core.Entities; // Assuming some entities might be used directly or for mapping
+using conViver.Application.Services; // For other services like AvisoService, etc.
+using conViver.Core.Interfaces; // For IRepository
+using Microsoft.EntityFrameworkCore; // For ToListAsync
+
+namespace conViver.Application.Services
+{
+    public class FeedService
+    {
+        private readonly AvisoService _avisoService;
+        private readonly VotacaoService _votacaoService;
+        private readonly ChamadoService _chamadoService;
+        private readonly OcorrenciaService _ocorrenciaService;
+        private readonly DocumentoService _documentoService;
+        private readonly EncomendaService _encomendaService;
+        private readonly FinanceiroService _financeiroService;
+        private readonly ReservaService _reservaService;
+        private readonly IRepository<Votacao> _votacaoRepository;
+        private readonly IRepository<Encomenda> _encomendaRepository;
+        private readonly IRepository<Usuario> _usuarioRepository;
+        private readonly IRepository<Unidade> _unidadeRepository;
+        private readonly IRepository<Reserva> _reservaRepository; // Added for Reserva queries
+
+        public FeedService(
+            AvisoService avisoService,
+            VotacaoService votacaoService,
+            IRepository<Votacao> votacaoRepository,
+            ChamadoService chamadoService,
+            OcorrenciaService ocorrenciaService,
+            DocumentoService documentoService,
+            EncomendaService encomendaService,
+            IRepository<Encomenda> encomendaRepository,
+            IRepository<Usuario> usuarioRepository,
+            IRepository<Unidade> unidadeRepository,
+            IRepository<Reserva> reservaRepository, // Added
+            FinanceiroService financeiroService,
+            ReservaService reservaService)
+        {
+            _avisoService = avisoService;
+            _votacaoService = votacaoService;
+            _votacaoRepository = votacaoRepository;
+            _chamadoService = chamadoService;
+            _ocorrenciaService = ocorrenciaService;
+            _documentoService = documentoService;
+            _encomendaService = encomendaService;
+            _encomendaRepository = encomendaRepository;
+            _usuarioRepository = usuarioRepository;
+            _unidadeRepository = unidadeRepository;
+            _reservaRepository = reservaRepository; // Added
+            _financeiroService = financeiroService;
+            _reservaService = reservaService;
+        }
+
+        public async Task<IEnumerable<FeedItemDto>> GetFeedAsync(
+            Guid condominioId,
+            Guid usuarioId,
+            int pageNumber,
+            int pageSize,
+            string? categoriaFiltro,
+            DateTime? periodoInicio,
+            DateTime? periodoFim,
+            CancellationToken ct = default)
+        {
+            var allFeedItems = new List<FeedItemDto>();
+
+            // Fetch and transform data from each source
+            allFeedItems.AddRange(await FetchAvisosAsync(condominioId, usuarioId, ct));
+            allFeedItems.AddRange(await FetchEnquetesAsync(condominioId, usuarioId, ct));
+            allFeedItems.AddRange(await FetchChamadosAsync(condominioId, usuarioId, ct));
+            allFeedItems.AddRange(await FetchOcorrenciasAsync(condominioId, usuarioId, ct));
+            allFeedItems.AddRange(await FetchEncomendasPendentesAsync(condominioId, usuarioId, ct));
+            allFeedItems.AddRange(await FetchLembretesBoletoAsync(condominioId, usuarioId, ct));
+            allFeedItems.AddRange(await FetchDocumentosRecentesAsync(condominioId, usuarioId, ct));
+            allFeedItems.AddRange(await FetchReservasConfirmadasAsync(condominioId, usuarioId, ct));
+
+            // Apply category and period filters
+            var filteredItems = allFeedItems.AsQueryable();
+
+            if (!string.IsNullOrEmpty(categoriaFiltro))
+            {
+                filteredItems = filteredItems.Where(item => item.Categoria == categoriaFiltro || item.ItemType == categoriaFiltro);
+            }
+
+            if (periodoInicio.HasValue)
+            {
+                filteredItems = filteredItems.Where(item => item.DataHoraPrincipal >= periodoInicio.Value);
+            }
+
+            if (periodoFim.HasValue)
+            {
+                filteredItems = filteredItems.Where(item => item.DataHoraPrincipal <= periodoFim.Value);
+            }
+
+            // Implement sorting
+            var sortedItems = filteredItems
+                .OrderBy(item => item.PrioridadeOrdenacao) // Top-fixed items first
+                .ThenByDescending(item => item.DataHoraPrincipal); // Then by main date descending
+
+            // Implement pagination
+            var paginatedItems = sortedItems
+                .Skip((pageNumber - 1) * pageSize)
+                .Take(pageSize)
+                .ToList(); // Execute query
+
+            return paginatedItems;
+        }
+
+        // Placeholder for private helper methods
+        private async Task<IEnumerable<FeedItemDto>> FetchAvisosAsync(Guid condominioId, Guid usuarioId, CancellationToken ct)
+        {
+            var avisos = await _avisoService.ListarAsync(condominioId, ct);
+            var feedItems = new List<FeedItemDto>();
+
+            foreach (var aviso in avisos)
+            {
+                feedItems.Add(new FeedItemDto
+                {
+                    ItemType = "Aviso",
+                    Id = aviso.Id,
+                    Titulo = aviso.Titulo,
+                    Resumo = TruncateString(aviso.Corpo, 100) ?? "Consulte para mais detalhes.", // Simple truncation
+                    DataHoraPrincipal = aviso.PublicadoEm,
+                    DataHoraAtualizacao = aviso.UpdatedAt,
+                    PrioridadeOrdenacao = "urgente".Equals(aviso.Categoria, StringComparison.OrdinalIgnoreCase) ? 0 : 1,
+                    UrlDestino = $"/app/avisos/{aviso.Id}", // Example URL
+                    Icone = "icon-aviso", // Example icon class
+                    Status = null, // Avisos might not have a distinct status for the feed view itself
+                    Categoria = aviso.Categoria,
+                    DetalhesAdicionais = new { aviso.Corpo } // Optional: send full body if needed by UI
+                });
+            }
+            return feedItems;
+        }
+
+        private async Task<IEnumerable<FeedItemDto>> FetchEnquetesAsync(Guid condominioId, Guid usuarioId, CancellationToken ct)
+        {
+            var feedItems = new List<FeedItemDto>();
+
+            // Fetch active enquetes (prioritized)
+            var enquetesAbertas = await _votacaoService.ListarAbertasAsync(condominioId, ct);
+            foreach (var enquete in enquetesAbertas)
+            {
+                feedItems.Add(new FeedItemDto
+                {
+                    ItemType = "Enquete",
+                    Id = enquete.Id,
+                    Titulo = enquete.Titulo,
+                    Resumo = $"Enquete aberta. Término em: {enquete.DataFim?.ToString("dd/MM/yyyy HH:mm") ?? "Não definido"}",
+                    DataHoraPrincipal = enquete.DataInicio, // Or DataFim for sorting by end time? For now, DataInicio
+                    DataHoraAtualizacao = enquete.DataInicio, // Assuming no separate UpdatedAt for VotacaoResumoDto
+                    PrioridadeOrdenacao = 0, // Active enquetes are top-fixed
+                    UrlDestino = $"/app/enquetes/{enquete.Id}",
+                    Icone = "icon-enquete-ativa",
+                    Status = enquete.Status, // "Aberta"
+                    Categoria = "Votação", // Or some other relevant category
+                    DetalhesAdicionais = null // VotacaoResumoDto is already lean
+                });
+            }
+
+            // Fetch recently closed enquetes (non-prioritized)
+            // This demonstrates fetching other types of enquetes.
+            // We might need a dedicated method in VotacaoService or use IRepository<Votacao> here.
+            // For now, using IRepository<Votacao> as a placeholder for this capability.
+            var enquetesFechadasRecentemente = await _votacaoRepository.Query()
+                .Where(v => v.CondominioId == condominioId &&
+                             v.Status != "Aberta" &&
+                             v.DataFim >= DateTime.UtcNow.AddDays(-7)) // Example: closed in the last 7 days
+                .OrderByDescending(v => v.DataFim)
+                .Take(5) // Limit to a few recent ones
+                .Select(v => new VotacaoResumoDto // Assuming we map to a similar DTO or use the entity directly
+                {
+                    Id = v.Id,
+                    Titulo = v.Titulo,
+                    DataInicio = v.DataInicio,
+                    DataFim = v.DataFim,
+                    Status = v.Status
+                    // Descricao = v.Descricao // Add if needed for Resumo
+                })
+                .ToListAsync(ct);
+
+            foreach (var enquete in enquetesFechadasRecentemente)
+            {
+                feedItems.Add(new FeedItemDto
+                {
+                    ItemType = "Enquete",
+                    Id = enquete.Id,
+                    Titulo = enquete.Titulo,
+                    Resumo = $"Enquete encerrada em: {enquete.DataFim?.ToString("dd/MM/yyyy HH:mm") ?? "Data não disponível"}",
+                    DataHoraPrincipal = enquete.DataFim ?? enquete.DataInicio, // Use DataFim for closed ones
+                    DataHoraAtualizacao = enquete.DataFim ?? enquete.DataInicio, // Or an UpdatedAt field if available
+                    PrioridadeOrdenacao = 1, // Non-prioritized
+                    UrlDestino = $"/app/enquetes/{enquete.Id}/resultados",
+                    Icone = "icon-enquete-fechada",
+                    Status = enquete.Status,
+                    Categoria = "Votação",
+                    DetalhesAdicionais = null
+                });
+            }
+
+            return feedItems;
+        }
+
+        private async Task<IEnumerable<FeedItemDto>> FetchChamadosAsync(Guid condominioId, Guid usuarioId, CancellationToken ct)
+        {
+            // Assuming we want all statuses for the feed, null for status filter
+            var chamados = await _chamadoService.ListarChamadosPorUsuarioAsync(condominioId, usuarioId, null, ct);
+            var feedItems = new List<FeedItemDto>();
+
+            foreach (var chamado in chamados)
+            {
+                feedItems.Add(new FeedItemDto
+                {
+                    ItemType = "Chamado",
+                    Id = chamado.Id,
+                    Titulo = chamado.Titulo,
+                    Resumo = TruncateString(chamado.Descricao, 100) ?? "Consulte para mais detalhes.",
+                    DataHoraPrincipal = chamado.DataAbertura,
+                    // ChamadoDto does not have UpdatedAt. Using DataAbertura or DataResolucao if available.
+                    DataHoraAtualizacao = chamado.DataResolucao ?? chamado.DataAbertura,
+                    PrioridadeOrdenacao = 1, // Normal priority for chamados
+                    UrlDestino = $"/app/chamados/{chamado.Id}",
+                    Icone = "icon-chamado",
+                    Status = chamado.Status,
+                    Categoria = "Atendimento", // Or some other relevant category for chamados
+                    DetalhesAdicionais = new { chamado.RespostaDoSindico }
+                });
+            }
+            return feedItems;
+        }
+
+        private async Task<IEnumerable<FeedItemDto>> FetchOcorrenciasAsync(Guid condominioId, Guid usuarioId, CancellationToken ct)
+        {
+            // Assuming we want all statuses and types for the feed, null for status/tipo filters
+            var ocorrencias = await _ocorrenciaService.ListarOcorrenciasPorUsuarioAsync(condominioId, usuarioId, null, null, ct);
+            var feedItems = new List<FeedItemDto>();
+
+            foreach (var ocorrencia in ocorrencias)
+            {
+                feedItems.Add(new FeedItemDto
+                {
+                    ItemType = "Ocorrencia",
+                    Id = ocorrencia.Id,
+                    Titulo = ocorrencia.Titulo,
+                    Resumo = TruncateString(ocorrencia.Descricao, 100) ?? "Consulte para mais detalhes.",
+                    DataHoraPrincipal = ocorrencia.DataOcorrencia,
+                    DataHoraAtualizacao = ocorrencia.UpdatedAt,
+                    PrioridadeOrdenacao = 1, // Normal priority
+                    UrlDestino = $"/app/ocorrencias/{ocorrencia.Id}",
+                    Icone = "icon-ocorrencia",
+                    Status = ocorrencia.Status,
+                    Categoria = ocorrencia.Tipo, // Using Ocorrencia.Tipo as Categoria for the feed item
+                    DetalhesAdicionais = new { ocorrencia.RespostaAdministracao }
+                });
+            }
+            return feedItems;
+        }
+
+        private async Task<IEnumerable<FeedItemDto>> FetchEncomendasPendentesAsync(Guid condominioId, Guid usuarioId, CancellationToken ct)
+        {
+            var feedItems = new List<FeedItemDto>();
+            var usuario = await _usuarioRepository.GetByIdAsync(usuarioId, ct);
+
+            if (usuario == null || !usuario.UnidadeId.HasValue)
+            {
+                return feedItems; // No UnidadeId for the user, so no encomendas to fetch for them
+            }
+
+            var unidadeId = usuario.UnidadeId.Value;
+
+            // Verify if the user's Unidade belongs to the provided CondominioId
+            var unidade = await _unidadeRepository.GetByIdAsync(unidadeId, ct);
+            if (unidade == null || unidade.CondominioId != condominioId)
+            {
+                // This unidade does not belong to the expected condominio, or unidade not found.
+                // This check ensures data integrity and security.
+                return feedItems;
+            }
+
+            // Fetch encomendas for the user's unidade
+            var encomendas = await _encomendaRepository.Query()
+                .Where(e => e.UnidadeId == unidadeId) // Corrected: Encomenda does not have CondominioId directly
+                .OrderByDescending(e => e.RecebidoEm)
+                .ToListAsync(ct);
+
+            foreach (var encomenda in encomendas)
+            {
+                bool isPendente = encomenda.Status == Core.Enums.EncomendaStatus.AguardandoRetirada ||
+                                  encomenda.Status == Core.Enums.EncomendaStatus.DisponivelParaRetirada; // Add other pending statuses if any
+
+                feedItems.Add(new FeedItemDto
+                {
+                    ItemType = "Encomenda",
+                    Id = encomenda.Id,
+                    Titulo = $"Encomenda: {encomenda.Remetente ?? "Origem desconhecida"}",
+                    Resumo = encomenda.Descricao ?? $"Código: {encomenda.CodigoRastreio ?? "N/A"}. Observações: {encomenda.Observacoes ?? "Nenhuma"}",
+                    DataHoraPrincipal = encomenda.RecebidoEm,
+                    DataHoraAtualizacao = encomenda.UpdatedAt, // Assuming Encomenda has UpdatedAt
+                    PrioridadeOrdenacao = isPendente ? 0 : 1,
+                    UrlDestino = $"/app/encomendas/{encomenda.Id}",
+                    Icone = isPendente ? "icon-encomenda-pendente" : "icon-encomenda",
+                    Status = encomenda.Status.ToString(), // Enum to string
+                    Categoria = "Portaria",
+                    DetalhesAdicionais = new { encomenda.CodigoRastreio, encomenda.Remetente, encomenda.Observacoes }
+                });
+            }
+            return feedItems;
+        }
+
+        private async Task<IEnumerable<FeedItemDto>> FetchLembretesBoletoAsync(Guid condominioId, Guid usuarioId, CancellationToken ct)
+        {
+            var feedItems = new List<FeedItemDto>();
+            var usuario = await _usuarioRepository.GetByIdAsync(usuarioId, ct);
+
+            if (usuario == null || !usuario.UnidadeId.HasValue)
+            {
+                return feedItems; // User or their UnidadeId not found
+            }
+            var unidadeId = usuario.UnidadeId.Value;
+
+            // Fetch "Pendente" cobrancas for the whole condominio.
+            // "Pendente" status in ListarCobrancasAsync covers: Gerado, Registrado, Enviado, Vencido
+            var todasCobrancasPendentesCondominio = await _financeiroService.ListarCobrancasAsync(condominioId, "Pendente");
+
+            // Filter for the current user's unidade
+            var cobrancasUsuario = todasCobrancasPendentesCondominio.Where(c => c.UnidadeId == unidadeId);
+
+            var hoje = DateTime.UtcNow.Date;
+            var diasAntecedenciaLembrete = 3; // Make this configurable if needed
+
+            foreach (var cobranca in cobrancasUsuario)
+            {
+                // Check if BoletoStatus enum can be parsed from cobranca.StatusCobranca for more robust check
+                bool isPagoOuCancelado = cobranca.StatusCobranca.Equals(Core.Enums.BoletoStatus.Pago.ToString(), StringComparison.OrdinalIgnoreCase) ||
+                                        cobranca.StatusCobranca.Equals(Core.Enums.BoletoStatus.Cancelado.ToString(), StringComparison.OrdinalIgnoreCase);
+
+                if (isPagoOuCancelado) continue; // Skip paid or canceled boletos
+
+                bool venceEmBreve = cobranca.DataVencimento.Date >= hoje &&
+                                    cobranca.DataVencimento.Date <= hoje.AddDays(diasAntecedenciaLembrete);
+
+                // Also include recently overdue items if they should be prioritized in feed
+                bool recentermenteVencido = cobranca.DataVencimento.Date < hoje &&
+                                           cobranca.DataVencimento.Date >= hoje.AddDays(-7); // Example: vencido nos últimos 7 dias
+
+                int prioridade = 1; // Normal
+                string titulo = $"Boleto: {cobranca.NomeSacado ?? "Sua unidade"}";
+                string resumo = $"Valor: {cobranca.Valor:C}, Vencimento: {cobranca.DataVencimento:dd/MM/yyyy}.";
+
+                if (venceEmBreve)
+                {
+                    prioridade = 0; // Top-fixed
+                    titulo = $"Lembrete! Boleto vence em breve: {cobranca.NomeSacado ?? "Sua unidade"}";
+                    resumo = $"Valor: {cobranca.Valor:C}. Vence em {cobranca.DataVencimento:dd/MM/yyyy}. Não perca o prazo!";
+                }
+                else if (recentermenteVencido)
+                {
+                    prioridade = 0; // Also prioritize recently overdue
+                    titulo = $"Atenção! Boleto vencido: {cobranca.NomeSacado ?? "Sua unidade"}";
+                    resumo = $"Valor: {cobranca.Valor:C}. Venceu em {cobranca.DataVencimento:dd/MM/yyyy}. Regularize!";
+                }
+
+
+                feedItems.Add(new FeedItemDto
+                {
+                    ItemType = "BoletoLembrete",
+                    Id = cobranca.Id, // Original Boleto ID
+                    Titulo = titulo,
+                    Resumo = resumo,
+                    DataHoraPrincipal = cobranca.DataVencimento,
+                    DataHoraAtualizacao = cobranca.DataVencimento, // Assuming no specific update timestamp for CobrancaDto apart from DataVencimento
+                    PrioridadeOrdenacao = prioridade,
+                    UrlDestino = cobranca.LinkSegundaVia ?? $"/app/financeiro/cobrancas/{cobranca.Id}",
+                    Icone = prioridade == 0 ? "icon-boleto-urgente" : "icon-boleto",
+                    Status = cobranca.StatusCobranca,
+                    Categoria = "Financeiro",
+                    DetalhesAdicionais = new { cobranca.Valor, cobranca.NomeSacado }
+                });
+            }
+            return feedItems;
+        }
+
+        private async Task<IEnumerable<FeedItemDto>> FetchDocumentosRecentesAsync(Guid condominioId, Guid usuarioId, CancellationToken ct)
+        {
+            // Fetch all documents for the condominio, ordered by most recent by default from the service
+            var documentos = await _documentoService.ListarDocumentosAsync(condominioId, null, ct);
+            var feedItems = new List<FeedItemDto>();
+
+            // Optional: Limit the number of documents shown in the feed, e.g., top 10 or 20 most recent.
+            // For now, taking all returned by the service.
+            // var documentosParaFeed = documentos.Take(10);
+
+            foreach (var doc in documentos) // Use 'documentos' or 'documentosParaFeed'
+            {
+                feedItems.Add(new FeedItemDto
+                {
+                    ItemType = "Documento",
+                    Id = doc.Id,
+                    Titulo = doc.TituloDescritivo,
+                    Resumo = $"Novo documento '{doc.NomeArquivoOriginal}' na categoria '{doc.Categoria}'.",
+                    DataHoraPrincipal = doc.DataUpload,
+                    DataHoraAtualizacao = doc.DataUpload, // Assuming DataUpload is the most relevant update timestamp
+                    PrioridadeOrdenacao = 1, // Normal priority
+                    UrlDestino = doc.Url, // This should be the download/view link
+                    Icone = "icon-documento",
+                    Status = null, // Documents don't typically have a feed-relevant status like "Pendente"
+                    Categoria = doc.Categoria,
+                    DetalhesAdicionais = new { doc.NomeArquivoOriginal, doc.TipoArquivo, doc.TamanhoArquivoBytes }
+                });
+            }
+            return feedItems;
+        }
+
+        private async Task<IEnumerable<FeedItemDto>> FetchReservasConfirmadasAsync(Guid condominioId, Guid usuarioId, CancellationToken ct)
+        {
+            var feedItems = new List<FeedItemDto>();
+            var usuario = await _usuarioRepository.GetByIdAsync(usuarioId, ct);
+
+            if (usuario == null || !usuario.UnidadeId.HasValue)
+            {
+                return feedItems; // User or their UnidadeId not found
+            }
+            var unidadeId = usuario.UnidadeId.Value;
+
+            // Verify Unidade belongs to Condominio (important if Reserva doesn't store CondominioId)
+            var unidade = await _unidadeRepository.GetByIdAsync(unidadeId, ct);
+            if (unidade == null || unidade.CondominioId != condominioId)
+            {
+                return feedItems;
+            }
+
+            var hoje = DateTime.UtcNow;
+            // Fetch recent confirmed/approved reservations for the user's unidade
+            // Assuming ReservaStatus.Confirmada or Aprovada means it's set for the user.
+            var reservas = await _reservaRepository.Query() // Corrected to use _reservaRepository
+                .Where(r => r.UnidadeId == unidadeId &&
+                             (r.Status == Core.Enums.ReservaStatus.Confirmada || r.Status == Core.Enums.ReservaStatus.Aprovada) &&
+                             r.Inicio >= hoje.AddDays(-7) && // Example: happening in the last 7 days
+                             r.Inicio <= hoje.AddDays(30))  // Example: or in the next 30 days
+                .OrderBy(r => r.Inicio) // Show upcoming ones first, or recently past
+                .ToListAsync(ct);
+
+            foreach (var reserva in reservas)
+            {
+                feedItems.Add(new FeedItemDto
+                {
+                    ItemType = "Reserva",
+                    Id = reserva.Id,
+                    Titulo = $"Reserva Confirmada: {reserva.Area}",
+                    Resumo = $"Sua reserva para {reserva.Area} está confirmada para {reserva.Inicio:dd/MM/yyyy HH:mm} até {reserva.Fim:HH:mm}.",
+                    DataHoraPrincipal = reserva.Inicio,
+                    DataHoraAtualizacao = reserva.UpdatedAt,
+                    PrioridadeOrdenacao = 1, // Normal priority
+                    UrlDestino = $"/app/reservas/{reserva.Id}", // Or a link to a calendar view
+                    Icone = "icon-reserva-confirmada",
+                    Status = reserva.Status.ToString(),
+                    Categoria = "Reservas",
+                    DetalhesAdicionais = new { reserva.Area, reserva.Fim, reserva.Taxa }
+                });
+            }
+            return feedItems;
+        }
+
+        // Helper for truncating strings, can be moved to a utility class
+        private static string? TruncateString(string? str, int maxLength)
+        {
+            if (string.IsNullOrEmpty(str))
+                return str;
+            return str.Length <= maxLength ? str : str.Substring(0, maxLength) + "...";
+        }
+    }
+}

--- a/conViver.Application/Services/OcorrenciaService.cs
+++ b/conViver.Application/Services/OcorrenciaService.cs
@@ -1,0 +1,153 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using conViver.Core.DTOs;
+using conViver.Core.Entities;
+using conViver.Core.Interfaces;
+using Microsoft.EntityFrameworkCore; // Added for ToListAsync
+
+namespace conViver.Application.Services
+{
+    public class OcorrenciaService
+    {
+        private readonly IRepository<Ocorrencia> _ocorrenciaRepository;
+        // private readonly INotificacaoService _notificacaoService; // Assuming you might have a notification service
+
+        public OcorrenciaService(IRepository<Ocorrencia> ocorrenciaRepository /*, INotificacaoService notificacaoService*/)
+        {
+            _ocorrenciaRepository = ocorrenciaRepository;
+            // _notificacaoService = notificacaoService;
+        }
+
+        public async Task<Ocorrencia> RegistrarOcorrenciaAsync(Guid condominioId, Guid usuarioId, OcorrenciaInputDto input, CancellationToken ct = default)
+        {
+            var ocorrencia = new Ocorrencia
+            {
+                Id = Guid.NewGuid(),
+                CondominioId = condominioId,
+                UsuarioId = usuarioId,
+                UnidadeId = input.UnidadeId,
+                Titulo = input.Titulo,
+                Descricao = input.Descricao,
+                Fotos = input.Fotos ?? new List<string>(),
+                Tipo = input.Tipo,
+                DataOcorrencia = input.DataOcorrencia,
+                Status = "Registrada", // Initial status
+                CreatedAt = DateTime.UtcNow,
+                UpdatedAt = DateTime.UtcNow
+            };
+
+            await _ocorrenciaRepository.AddAsync(ocorrencia, ct);
+            // Potentially send notifications after creating
+            // await _notificacaoService.NotificarNovaOcorrenciaAsync(ocorrencia);
+            return ocorrencia;
+        }
+
+        public async Task<IEnumerable<OcorrenciaDto>> ListarOcorrenciasPorUsuarioAsync(Guid condominioId, Guid usuarioId, string? status, string? tipo, CancellationToken ct = default)
+        {
+            var query = _ocorrenciaRepository.Query()
+                .Where(o => o.CondominioId == condominioId && o.UsuarioId == usuarioId);
+
+            if (!string.IsNullOrEmpty(status))
+            {
+                query = query.Where(o => o.Status == status);
+            }
+
+            if (!string.IsNullOrEmpty(tipo))
+            {
+                query = query.Where(o => o.Tipo == tipo);
+            }
+
+            var ocorrencias = await query.ToListAsync(ct); // Changed to use ToListAsync
+            return ocorrencias.Select(MapToOcorrenciaDto);
+        }
+
+        public async Task<IEnumerable<OcorrenciaDto>> ListarOcorrenciasParaGestaoAsync(Guid condominioId, string? status, string? tipo, CancellationToken ct = default)
+        {
+            var query = _ocorrenciaRepository.Query()
+                .Where(o => o.CondominioId == condominioId);
+
+            if (!string.IsNullOrEmpty(status))
+            {
+                query = query.Where(o => o.Status == status);
+            }
+
+            if (!string.IsNullOrEmpty(tipo))
+            {
+                query = query.Where(o => o.Tipo == tipo);
+            }
+
+            var ocorrencias = await query.ToListAsync(ct); // Changed to use ToListAsync
+            return ocorrencias.Select(MapToOcorrenciaDto);
+        }
+
+        public async Task<OcorrenciaDto?> ObterOcorrenciaPorIdAsync(Guid ocorrenciaId, Guid condominioId, Guid usuarioId, bool isGestor, CancellationToken ct = default)
+        {
+            var ocorrencia = await _ocorrenciaRepository.GetByIdAsync(ocorrenciaId, ct);
+
+            if (ocorrencia == null || ocorrencia.CondominioId != condominioId)
+            {
+                return null; // Or throw NotFoundException
+            }
+
+            // If not a manager, user can only see their own occurrences
+            if (!isGestor && ocorrencia.UsuarioId != usuarioId)
+            {
+                return null; // Or throw UnauthorizedAccessException
+            }
+
+            return MapToOcorrenciaDto(ocorrencia);
+        }
+
+        public async Task<OcorrenciaDto?> AtualizarOcorrenciaAsync(Guid ocorrenciaId, Guid condominioId, Guid gestorUserId, OcorrenciaUpdateDto updateDto, CancellationToken ct = default)
+        {
+            var ocorrencia = await _ocorrenciaRepository.GetByIdAsync(ocorrenciaId, ct);
+
+            if (ocorrencia == null || ocorrencia.CondominioId != condominioId)
+            {
+                return null; // Or throw NotFoundException
+            }
+
+            // Logic to ensure only authorized personnel (e.g., admin/sindico) can update certain fields
+            // This might involve checking gestorUserId against a list of authorized users or roles.
+            // For now, we assume if this method is called, the user is authorized for simplicity.
+
+            ocorrencia.Status = updateDto.Status;
+            ocorrencia.RespostaAdministracao = updateDto.RespostaAdministracao;
+            ocorrencia.UpdatedAt = DateTime.UtcNow;
+
+            if (updateDto.Status == "Resolvida" || updateDto.Status == "Cancelada")
+            {
+                ocorrencia.DataResolucao = DateTime.UtcNow;
+            }
+
+            await _ocorrenciaRepository.UpdateAsync(ocorrencia, ct);
+            // Potentially send notifications about the update
+            // await _notificacaoService.NotificarOcorrenciaAtualizadaAsync(ocorrencia);
+            return MapToOcorrenciaDto(ocorrencia);
+        }
+
+        private OcorrenciaDto MapToOcorrenciaDto(Ocorrencia ocorrencia)
+        {
+            return new OcorrenciaDto
+            {
+                Id = ocorrencia.Id,
+                CondominioId = ocorrencia.CondominioId,
+                UnidadeId = ocorrencia.UnidadeId,
+                UsuarioId = ocorrencia.UsuarioId,
+                Titulo = ocorrencia.Titulo,
+                Descricao = ocorrencia.Descricao,
+                Fotos = ocorrencia.Fotos,
+                Status = ocorrencia.Status,
+                Tipo = ocorrencia.Tipo,
+                DataOcorrencia = ocorrencia.DataOcorrencia,
+                DataResolucao = ocorrencia.DataResolucao,
+                RespostaAdministracao = ocorrencia.RespostaAdministracao,
+                CreatedAt = ocorrencia.CreatedAt,
+                UpdatedAt = ocorrencia.UpdatedAt
+            };
+        }
+    }
+}

--- a/conViver.Core/DTOs/FeedItemDto.cs
+++ b/conViver.Core/DTOs/FeedItemDto.cs
@@ -1,0 +1,20 @@
+using System;
+
+namespace conViver.Core.DTOs
+{
+    public class FeedItemDto
+    {
+        public string ItemType { get; set; } // e.g., "Aviso", "Enquete", "Chamado", "Ocorrencia", "Documento", "Encomenda", "BoletoLembrete", "Reserva"
+        public Guid Id { get; set; } // Original ID of the item
+        public string Titulo { get; set; }
+        public string Resumo { get; set; } // A short description or snippet
+        public DateTime DataHoraPrincipal { get; set; } // The main date/time for sorting, e.g., DataPublicacao, DataAbertura, DataVencimento
+        public DateTime DataHoraAtualizacao { get; set; } // Used for secondary sorting or display
+        public int PrioridadeOrdenacao { get; set; } // 0 for top-fixed, 1 for normal
+        public string? UrlDestino { get; set; } // Link to the item's detail page/modal trigger
+        public string? Icone { get; set; } // A class name or identifier for an icon
+        public string? Status { get; set; } // Status of the item, if applicable
+        public string? Categoria { get; set; } // Original category of the item
+        public object? DetalhesAdicionais { get; set; } // Optional: for any extra info specific to the item type
+    }
+}

--- a/conViver.Core/DTOs/OcorrenciaDtos.cs
+++ b/conViver.Core/DTOs/OcorrenciaDtos.cs
@@ -1,0 +1,39 @@
+using System;
+using System.Collections.Generic;
+
+namespace conViver.Core.DTOs
+{
+    public class OcorrenciaDto
+    {
+        public Guid Id { get; set; }
+        public Guid CondominioId { get; set; }
+        public Guid? UnidadeId { get; set; }
+        public Guid UsuarioId { get; set; }
+        public string Titulo { get; set; }
+        public string Descricao { get; set; }
+        public List<string> Fotos { get; set; }
+        public string Status { get; set; }
+        public string Tipo { get; set; }
+        public DateTime DataOcorrencia { get; set; }
+        public DateTime? DataResolucao { get; set; }
+        public string? RespostaAdministracao { get; set; }
+        public DateTime CreatedAt { get; set; }
+        public DateTime UpdatedAt { get; set; }
+    }
+
+    public class OcorrenciaInputDto
+    {
+        public string Titulo { get; set; }
+        public string Descricao { get; set; }
+        public List<string> Fotos { get; set; } = new List<string>();
+        public string Tipo { get; set; }
+        public DateTime DataOcorrencia { get; set; }
+        public Guid? UnidadeId { get; set; }
+    }
+
+    public class OcorrenciaUpdateDto
+    {
+        public string Status { get; set; }
+        public string? RespostaAdministracao { get; set; }
+    }
+}

--- a/conViver.Core/Entities/Ocorrencia.cs
+++ b/conViver.Core/Entities/Ocorrencia.cs
@@ -1,0 +1,23 @@
+using System;
+using System.Collections.Generic;
+
+namespace conViver.Core.Entities
+{
+    public class Ocorrencia
+    {
+        public Guid Id { get; set; }
+        public Guid CondominioId { get; set; }
+        public Guid? UnidadeId { get; set; }
+        public Guid UsuarioId { get; set; }
+        public string Titulo { get; set; }
+        public string Descricao { get; set; }
+        public List<string> Fotos { get; set; } = new List<string>();
+        public string Status { get; set; } // e.g., "Registrada", "EmAnalise", "Resolvida", "Cancelada"
+        public string Tipo { get; set; } // e.g., "Barulho", "Seguranca", "Infraestrutura", "Outros"
+        public DateTime DataOcorrencia { get; set; } // Date the event happened
+        public DateTime? DataResolucao { get; set; }
+        public string? RespostaAdministracao { get; set; }
+        public DateTime CreatedAt { get; set; } = DateTime.UtcNow;
+        public DateTime UpdatedAt { get; set; } = DateTime.UtcNow;
+    }
+}

--- a/conViver.Infrastructure/Data/Contexts/ConViverDbContext.cs
+++ b/conViver.Infrastructure/Data/Contexts/ConViverDbContext.cs
@@ -25,6 +25,7 @@ public class ConViverDbContext : DbContext
     public DbSet<OpcaoVotacao> OpcoesVotacao => Set<OpcaoVotacao>();
     public DbSet<VotoRegistrado> VotosRegistrados => Set<VotoRegistrado>();
     public DbSet<Chamado> Chamados => Set<Chamado>();
+    public DbSet<Ocorrencia> Ocorrencias => Set<Ocorrencia>(); // Added Ocorrencia DbSet
     public DbSet<AvaliacaoPrestador> AvaliacoesPrestadores { get; set; } = null!; // Adicionado DbSet para AvaliacaoPrestador
 
     protected override void OnModelCreating(ModelBuilder modelBuilder)

--- a/conViver.Infrastructure/Migrations/20250619235551_AddOcorrenciaEntity.Designer.cs
+++ b/conViver.Infrastructure/Migrations/20250619235551_AddOcorrenciaEntity.Designer.cs
@@ -2,6 +2,7 @@
 using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using conViver.Infrastructure.Data.Contexts;
 
@@ -10,9 +11,11 @@ using conViver.Infrastructure.Data.Contexts;
 namespace conViver.Infrastructure.Migrations
 {
     [DbContext(typeof(ConViverDbContext))]
-    partial class ConViverDbContextModelSnapshot : ModelSnapshot
+    [Migration("20250619235551_AddOcorrenciaEntity")]
+    partial class AddOcorrenciaEntity
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder.HasAnnotation("ProductVersion", "8.0.6");

--- a/conViver.Infrastructure/Migrations/20250619235551_AddOcorrenciaEntity.cs
+++ b/conViver.Infrastructure/Migrations/20250619235551_AddOcorrenciaEntity.cs
@@ -1,0 +1,46 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace conViver.Infrastructure.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddOcorrenciaEntity : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateTable(
+                name: "Ocorrencias",
+                columns: table => new
+                {
+                    Id = table.Column<Guid>(type: "TEXT", nullable: false),
+                    CondominioId = table.Column<Guid>(type: "TEXT", nullable: false),
+                    UnidadeId = table.Column<Guid>(type: "TEXT", nullable: true),
+                    UsuarioId = table.Column<Guid>(type: "TEXT", nullable: false),
+                    Titulo = table.Column<string>(type: "TEXT", nullable: false),
+                    Descricao = table.Column<string>(type: "TEXT", nullable: false),
+                    Fotos = table.Column<string>(type: "TEXT", nullable: false),
+                    Status = table.Column<string>(type: "TEXT", nullable: false),
+                    Tipo = table.Column<string>(type: "TEXT", nullable: false),
+                    DataOcorrencia = table.Column<DateTime>(type: "TEXT", nullable: false),
+                    DataResolucao = table.Column<DateTime>(type: "TEXT", nullable: true),
+                    RespostaAdministracao = table.Column<string>(type: "TEXT", nullable: true),
+                    CreatedAt = table.Column<DateTime>(type: "TEXT", nullable: false),
+                    UpdatedAt = table.Column<DateTime>(type: "TEXT", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_Ocorrencias", x => x.Id);
+                });
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "Ocorrencias");
+        }
+    }
+}

--- a/conViver.Web/pages/comunicacao.html
+++ b/conViver.Web/pages/comunicacao.html
@@ -19,24 +19,25 @@
     </nav>
     <main class="cv-container">
         <div class="cv-tabs">
-            <button class="cv-tab-button active" id="tab-mural">Mural Digital</button>
-            <button class="cv-tab-button" id="tab-enquetes">Enquetes e Votações</button>
-            <button class="cv-tab-button" id="tab-chamados">Chamados e Solicitações</button>
-            <button class="cv-tab-button" id="tab-documentos">Biblioteca de Documentos</button>
+            <button class="cv-tab-button active" id="tab-mural">Mural</button>
+            <button class="cv-tab-button" id="tab-enquetes">Enquetes</button>
+            <button class="cv-tab-button" id="tab-solicitacoes">Solicitações</button>
         </div>
 
         <div class="cv-tab-content" id="content-mural">
-            <h2 class="communication__title">Mural Digital</h2>
+            <h2 class="communication__title">Mural</h2>
 
             <div class="filters-container cv-form-group">
                 <label for="category-filter">Categoria:</label>
                 <select id="category-filter" name="category-filter" class="cv-input">
                     <option value="">Todas</option>
-                    <option value="manutencao">🛠️ Manutenção</option>
-                    <option value="reservas">🏡 Reservas</option>
-                    <option value="comunicados">📢 Comunicados Gerais</option>
-                    <option value="enquetes">🗳️ Enquetes</option>
-                    <option value="assembleias">🧑‍⚖️ Assembleias</option>
+                    <option value="comunicados">Comunicados</option>
+                    <option value="enquetes">Enquetes</option>
+                    <option value="solicitacoes">Solicitações</option>
+                    <option value="ocorrencias">Ocorrências</option>
+                    <option value="documentos">Documentos</option>
+                    <option value="reservas">Reservas</option>
+                    <option value="servicos">Serviços</option>
                 </select>
 
                 <label for="period-filter">Período:</label>
@@ -57,7 +58,7 @@
         </div>
 
         <div class="cv-tab-content" id="content-enquetes" style="display:none;">
-            <h2 class="communication__title">Enquetes e Votações</h2>
+            <h2 class="communication__title">Enquetes</h2>
 
             <section id="enquetes-ativas-section" class="cv-section">
                 <h3>Enquetes Ativas</h3>
@@ -133,8 +134,8 @@
             </div>
         </div>
 
-        <div class="cv-tab-content" id="content-chamados" style="display:none;">
-            <h2 class="communication__title">Chamados e Solicitações</h2>
+        <div class="cv-tab-content" id="content-solicitacoes" style="display:none;">
+            <h2 class="communication__title">Solicitações</h2>
 
             <!-- Filters Section -->
             <section id="chamados-filters-section" class="filters-container cv-form-group">
@@ -236,10 +237,6 @@
             </div>
         </div>
 
-        <div class="cv-tab-content" id="content-documentos" style="display:none;">
-            <h2 class="communication__title">Biblioteca de Documentos</h2>
-            <!-- Placeholder for Documentos content -->
-            <p>Conteúdo da biblioteca de documentos aparecerá aqui.</p>
         </div>
     </main>
 


### PR DESCRIPTION
This commit introduces a comprehensive overhaul of the Digital Wall (Mural Digital) feature, transforming it into a dynamic, feed-style communication hub.

**Key Changes:**

**Backend:**
- **New 'Ocorrencia' Module:** Added full backend support for "Ocorrências" (Occurrences), including entity, DTOs, service, controller, and database migration. This allows you to report and track occurrences similar to "Chamados".
- **Unified Feed Service (`FeedService`):** Developed a new service to aggregate various types of information into a single feed. This includes:
    - Avisos (Notices)
    - Enquetes (Polls - active and closed)
    - Chamados (Requests)
    - Ocorrências (Occurrences)
    - Documentos (Recent updates)
    - Encomendas (Pending deliveries)
    - Lembretes de Boleto (Upcoming and recently overdue)
    - Reservas (Confirmed reservations)
- **Feed Item Prioritization:** Implemented sorting logic to display "top-fixed" items (active enquetes, urgent comunicados, pending encomendas, boleto reminders) at the top of the feed, followed by other items sorted by date.
- **Unified Feed Controller (`FeedController`):** Created a new API endpoint (`/api/v1/feed`) to serve the paginated and filterable unified feed to the frontend. Supports filtering by category and date range.

**Frontend (`comunicacao.html`, `comunicacao.js`):**
- **Restructured Navigation:**
    - Main page section remains "Comunicação".
    - Sub-tabs updated to: "Mural" (default, displays the unified feed), "Enquetes", and "Solicitações".
    - "Biblioteca de Documentos" tab removed as per requirements.
- **Unified Feed Display:**
    - The "Mural" tab now displays the unified feed with infinite scrolling.
    - Different item types are rendered with basic card structures.
- **Updated Filters:**
    - Category filter on the "Mural" tab updated with new options relevant to the unified feed (Comunicados, Enquetes, Solicitações, Ocorrências, Documentos, Reservas, Serviços).
    - Period filter (month picker) correctly translates to a date range for the API.
- **Sub-Tab Behavior:**
    - "Enquetes" and "Solicitações" tabs now act as quick filters for the main feed displayed on the "Mural" tab. They update the Mural's category filter and trigger a reload.
    - Item creation functionalities (FABs and modals for Avisos, Enquetes, Chamados) are retained and integrated.
- **Item Click Handling:** Implemented basic click handling for feed items. Avisos can be edited/deleted. Documentos and Boleto Lembretes link to URLs. Placeholders are in place for more detailed views of other item types.

**Overall Impact:**
This redesign significantly enhances the communication capabilities of the platform, providing you with a centralized, dynamic, and easily digestible feed of relevant information, much like a social media timeline for the condominium. The backend is now more extensible for future feed item types.