### PR TITLE
Fix: Resolve CS8618 nullable warnings and CS1061 error

### DIFF
--- a/conViver.Core/DTOs/OcorrenciaDtos.cs
+++ b/conViver.Core/DTOs/OcorrenciaDtos.cs
@@ -6,7 +6,7 @@ namespace conViver.Core.DTOs
 {
     public class PagedResultDto<T>
     {
-        public List<T> Items { get; set; }
+        public List<T> Items { get; set; } = new List<T>();
         public int TotalCount { get; set; }
         public int PageNumber { get; set; }
         public int PageSize { get; set; }
@@ -14,16 +14,16 @@ namespace conViver.Core.DTOs
 
     public class OcorrenciaInputDto
     {
-        public string Titulo { get; set; }
-        public string Descricao { get; set; }
+        public string Titulo { get; set; } = string.Empty;
+        public string Descricao { get; set; } = string.Empty;
         public OcorrenciaCategoria Categoria { get; set; }
         public OcorrenciaPrioridade Prioridade { get; set; } = OcorrenciaPrioridade.NORMAL;
     }
 
     public class OcorrenciaUpdateDto
     {
-        public string Titulo { get; set; }
-        public string Descricao { get; set; }
+        public string Titulo { get; set; } = string.Empty;
+        public string Descricao { get; set; } = string.Empty;
         public OcorrenciaCategoria Categoria { get; set; }
         public OcorrenciaPrioridade Prioridade { get; set; }
     }
@@ -31,66 +31,67 @@ namespace conViver.Core.DTOs
     public class OcorrenciaUsuarioInfoDto
     {
         public Guid Id { get; set; }
-        public string Nome { get; set; }
-        public string Unidade { get; set; }
+        public string Nome { get; set; } = string.Empty;
+        public string Unidade { get; set; } = string.Empty;
     }
 
     public class OcorrenciaAnexoDto
     {
         public Guid Id { get; set; }
-        public string Url { get; set; }
-        public string NomeArquivo { get; set; }
-        public string Tipo { get; set; }
+        public string Url { get; set; } = string.Empty;
+        public string NomeArquivo { get; set; } = string.Empty;
+        public string Tipo { get; set; } = string.Empty;
         public long Tamanho { get; set; }
     }
 
     public class OcorrenciaStatusHistoricoDto
     {
-        public string Status { get; set; }
+        public string Status { get; set; } = string.Empty;
         public DateTime Data { get; set; }
-        public string AlteradoPorNome { get; set; }
+        public string AlteradoPorNome { get; set; } = string.Empty;
     }
 
     public class OcorrenciaComentarioDto
     {
         public Guid Id { get; set; }
         public Guid UsuarioId { get; set; }
-        public string UsuarioNome { get; set; }
-        public string Texto { get; set; }
+        public string UsuarioNome { get; set; } = string.Empty;
+        public string Texto { get; set; } = string.Empty;
         public DateTime Data { get; set; }
     }
 
     public class OcorrenciaDetailsDto
     {
         public Guid Id { get; set; }
-        public string Titulo { get; set; }
-        public string Descricao { get; set; }
-        public string Categoria { get; set; }
-        public string Status { get; set; }
-        public string Prioridade { get; set; }
+        public string Titulo { get; set; } = string.Empty;
+        public string Descricao { get; set; } = string.Empty;
+        public string Categoria { get; set; } = string.Empty;
+        public string Status { get; set; } = string.Empty;
+        public string Prioridade { get; set; } = string.Empty;
         public DateTime DataAbertura { get; set; }
         public DateTime DataAtualizacao { get; set; }
-        public OcorrenciaUsuarioInfoDto Usuario { get; set; }
-        public List<OcorrenciaAnexoDto> Anexos { get; set; }
-        public List<OcorrenciaStatusHistoricoDto> HistoricoStatus { get; set; }
-        public List<OcorrenciaComentarioDto> Comentarios { get; set; }
+        public OcorrenciaUsuarioInfoDto Usuario { get; set; } = null!;
+        public List<OcorrenciaAnexoDto> Anexos { get; set; } = new List<OcorrenciaAnexoDto>();
+        public List<OcorrenciaStatusHistoricoDto> HistoricoStatus { get; set; } = new List<OcorrenciaStatusHistoricoDto>();
+        public List<OcorrenciaComentarioDto> Comentarios { get; set; } = new List<OcorrenciaComentarioDto>();
     }
 
     public class OcorrenciaListItemDto
     {
         public Guid Id { get; set; }
-        public string Titulo { get; set; }
-        public string Categoria { get; set; }
-        public string Status { get; set; }
-        public string Prioridade { get; set; }
+        public string Titulo { get; set; } = string.Empty;
+    public string Descricao { get; set; } = string.Empty; // Added this property
+        public string Categoria { get; set; } = string.Empty;
+        public string Status { get; set; } = string.Empty;
+        public string Prioridade { get; set; } = string.Empty;
         public DateTime DataAbertura { get; set; }
         public DateTime DataAtualizacao { get; set; }
-        public string NomeUsuario { get; set; }
+        public string NomeUsuario { get; set; } = string.Empty;
     }
 
     public class OcorrenciaComentarioInputDto
     {
-        public string Texto { get; set; }
+        public string Texto { get; set; } = string.Empty;
     }
 
     public class OcorrenciaStatusInputDto

--- a/conViver.Core/Entities/Ocorrencia.cs
+++ b/conViver.Core/Entities/Ocorrencia.cs
@@ -19,11 +19,24 @@ namespace conViver.Core.Entities
         public Guid CondominioId { get; set; }
 
         public Usuario Usuario { get; set; }
-        public Unidade Unidade { get; set; }
+        public Unidade? Unidade { get; set; } // Made Unidade nullable
         public Condominio Condominio { get; set; }
 
         public ICollection<OcorrenciaAnexo> Anexos { get; set; }
         public ICollection<OcorrenciaComentario> Comentarios { get; set; }
         public ICollection<OcorrenciaStatusHistorico> HistoricoStatus { get; set; }
+
+        // Constructor to initialize non-nullable properties
+        public Ocorrencia()
+        {
+            Titulo = string.Empty;
+            Descricao = string.Empty;
+            Usuario = null!; // EF Core will populate this
+            // Unidade is nullable, no need to initialize to null!
+            Condominio = null!; // EF Core will populate this
+            Anexos = new List<OcorrenciaAnexo>();
+            Comentarios = new List<OcorrenciaComentario>();
+            HistoricoStatus = new List<OcorrenciaStatusHistorico>();
+        }
     }
 }

--- a/conViver.Core/Entities/OcorrenciaAnexo.cs
+++ b/conViver.Core/Entities/OcorrenciaAnexo.cs
@@ -12,5 +12,14 @@ namespace conViver.Core.Entities
         public long Tamanho { get; set; }
 
         public Ocorrencia Ocorrencia { get; set; }
+
+        // Constructor to initialize non-nullable properties
+        public OcorrenciaAnexo()
+        {
+            Url = string.Empty;
+            NomeArquivo = string.Empty;
+            Tipo = string.Empty;
+            Ocorrencia = null!; // EF Core will populate this
+        }
     }
 }

--- a/conViver.Core/Entities/OcorrenciaComentario.cs
+++ b/conViver.Core/Entities/OcorrenciaComentario.cs
@@ -12,5 +12,13 @@ namespace conViver.Core.Entities
 
         public Ocorrencia Ocorrencia { get; set; }
         public Usuario Usuario { get; set; } // Assuming Usuario entity exists in conViver.Core.Entities
+
+        // Constructor to initialize non-nullable properties
+        public OcorrenciaComentario()
+        {
+            Texto = string.Empty;
+            Ocorrencia = null!; // EF Core will populate this
+            Usuario = null!; // EF Core will populate this
+        }
     }
 }

--- a/conViver.Core/Entities/OcorrenciaStatusHistorico.cs
+++ b/conViver.Core/Entities/OcorrenciaStatusHistorico.cs
@@ -13,5 +13,12 @@ namespace conViver.Core.Entities
 
         public Ocorrencia Ocorrencia { get; set; }
         public Usuario AlteradoPor { get; set; } // Assuming Usuario entity exists in conViver.Core.Entities
+
+        // Constructor to initialize non-nullable properties
+        public OcorrenciaStatusHistorico()
+        {
+            Ocorrencia = null!; // EF Core will populate this
+            AlteradoPor = null!; // EF Core will populate this
+        }
     }
 }


### PR DESCRIPTION
This commit addresses a series of CS8618 warnings related to non-nullable properties not being initialized in constructors across various entities and DTOs. It also fixes a CS1061 compilation error in FeedService.cs.

Changes include:
- Added `Descricao` property to `OcorrenciaListItemDto` to resolve the CS1061 error in `FeedService.cs`.
- Added constructors to entity classes (`Ocorrencia`, `OcorrenciaAnexo`, `OcorrenciaStatusHistorico`, `OcorrenciaComentario`) to initialize non-nullable string properties to `string.Empty`, collection properties to empty lists, and navigation properties to `null!`.
- Made `Ocorrencia.Unidade` property nullable as its foreign key `UnidadeId` is nullable.
- Initialized non-nullable properties in various DTOs within `OcorrenciaDtos.cs` using default values (`string.Empty`, new lists, or `null!` for complex types expected to be populated by application logic).

These changes ensure proper initialization of non-nullable types, satisfying the compiler requirements and improving code robustness by preventing potential null reference exceptions.