### PR TITLE
Fix: Resolve compilation errors and nullable warnings

### DIFF
--- a/conViver.Infrastructure/Data/Contexts/ConViverDbContext.cs
+++ b/conViver.Infrastructure/Data/Contexts/ConViverDbContext.cs
@@ -26,7 +26,6 @@ public class ConViverDbContext : DbContext
     public DbSet<OpcaoVotacao> OpcoesVotacao => Set<OpcaoVotacao>();
     public DbSet<VotoRegistrado> VotosRegistrados => Set<VotoRegistrado>();
     public DbSet<Chamado> Chamados => Set<Chamado>();
-    public DbSet<Ocorrencia> Ocorrencias => Set<Ocorrencia>(); // Added Ocorrencia DbSet
     public DbSet<AvaliacaoPrestador> AvaliacoesPrestadores { get; set; } = null!; // Adicionado DbSet para AvaliacaoPrestador
 
     // Ocorrências


### PR DESCRIPTION
This commit addresses a CS0102 error caused by a duplicate DbSet definition in ConViverDbContext and incorporates previous fixes for CS8618 nullable warnings and a CS1061 error.

Detailed changes:
- Removed duplicate `DbSet<Ocorrencia> Ocorrencias` definition in `ConViverDbContext.cs`.
- Added `Descricao` property to `OcorrenciaListItemDto` to resolve CS1061 error in `FeedService.cs`.
- Added constructors to entity classes (`Ocorrencia`, `OcorrenciaAnexo`, `OcorrenciaStatusHistorico`, `OcorrenciaComentario`) to initialize non-nullable properties.
- Made `Ocorrencia.Unidade` property nullable.
- Initialized non-nullable properties in DTOs within `OcorrenciaDtos.cs`.

These changes ensure the project compiles successfully and improves code robustness by addressing nullability warnings.