### PR TITLE
Fix: Resolve 500 error by requiring CondominioId and UnidadeId at signup

### DIFF
--- a/conViver.API/Controllers/UsuariosController.cs
+++ b/conViver.API/Controllers/UsuariosController.cs
@@ -38,6 +38,17 @@ public class UsuariosController : ControllerBase // Renomear para AuthController
     {
         if (!ModelState.IsValid) return BadRequest(ModelState);
 
+        // Adicionar validações manuais para CondominioId e UnidadeId
+        if (request.CondominioId == null || request.CondominioId == Guid.Empty)
+        {
+            return BadRequest(new { error = "MISSING_CONDOMINIO_ID", message = "O CondominioId é obrigatório." });
+        }
+
+        if (request.UnidadeId == null || request.UnidadeId == Guid.Empty)
+        {
+            return BadRequest(new { error = "MISSING_UNIDADE_ID", message = "O UnidadeId é obrigatório." });
+        }
+
         var existing = await _usuarios.GetByEmailAsync(request.Email);
         if (existing != null)
         {
@@ -50,9 +61,9 @@ public class UsuariosController : ControllerBase // Renomear para AuthController
             Nome = request.Nome,
             Email = request.Email,
             SenhaHash = request.Senha, // O serviço _usuarios.AddAsync deve cuidar do hashing da senha
-            Perfil = PerfilUsuario.Morador // Perfil padrão, pode ser ajustado conforme regras de negócio
-            // CondominioId e UnidadeId podem ser definidos aqui se fornecidos no SignupRequestDto
-            // e se o usuário já é vinculado a um condomínio no momento do signup.
+            Perfil = PerfilUsuario.Morador, // Perfil padrão, pode ser ajustado conforme regras de negócio
+            CondominioId = request.CondominioId, // Adicionado
+            UnidadeId = request.UnidadeId // Adicionado
         };
         await _usuarios.AddAsync(usuario); // Assumindo que AddAsync faz o hash da senha
 

--- a/conViver.Core/DTOs/AuthDtos.cs
+++ b/conViver.Core/DTOs/AuthDtos.cs
@@ -20,8 +20,8 @@ public class SignupRequestDto
     public string Senha { get; set; } = string.Empty;
 
     // Opcional: Se o signup já vincula a um condomínio/unidade
-    // public Guid? CondominioId { get; set; }
-    // public Guid? UnidadeId { get; set; }
+    public Guid? CondominioId { get; set; }
+    public Guid? UnidadeId { get; set; }
     // public string? CodigoConvite { get; set; }
 }
 

--- a/conViver.Tests/API/AuthControllerTests.cs
+++ b/conViver.Tests/API/AuthControllerTests.cs
@@ -161,8 +161,9 @@ namespace conViver.Tests.API
             {
                 Nome = "New User",
                 Email = uniqueEmail,
-                Senha = "password123"
-                // UnidadeId and CondominioId might be needed if your DTO requires them
+                Senha = "password123",
+                CondominioId = Guid.NewGuid(), // Added
+                UnidadeId = Guid.NewGuid()      // Added
             };
 
             // Act
@@ -194,7 +195,9 @@ namespace conViver.Tests.API
             {
                 Nome = "Existing User",
                 Email = existingEmail,
-                Senha = "password123"
+                Senha = "password123",
+                CondominioId = Guid.NewGuid(), // Added
+                UnidadeId = Guid.NewGuid()      // Added
             };
             // First, create the user
             var firstResponse = await _client.PostAsJsonAsync("auth/signup", firstSignupRequest);
@@ -204,7 +207,9 @@ namespace conViver.Tests.API
             {
                 Nome = "Another User",
                 Email = existingEmail, // Same email
-                Senha = "password456"
+                Senha = "password456",
+                CondominioId = Guid.NewGuid(), // Added
+                UnidadeId = Guid.NewGuid()      // Added
             };
 
             // Act
@@ -315,6 +320,102 @@ namespace conViver.Tests.API
             var errorResponse = await response.Content.ReadFromJsonAsync<ErrorResponseDto>(); // Assuming a generic error DTO
             errorResponse?.Error.Should().Be("RESET_FAILED"); // Or check message if more consistent
             errorResponse?.Message.Should().Be("Não foi possível redefinir a senha. O token pode ser inválido ou ter expirado.");
+        }
+
+        [Fact]
+        public async Task Signup_WithMissingCondominioId_ReturnsBadRequest()
+        {
+            // Arrange
+            var signupRequest = new SignupRequestDto
+            {
+                Nome = "Test User",
+                Email = $"testuser_{Guid.NewGuid()}@example.com",
+                Senha = "password123",
+                CondominioId = null, // Missing CondominioId
+                UnidadeId = Guid.NewGuid()
+            };
+
+            // Act
+            var response = await _client.PostAsJsonAsync("auth/signup", signupRequest);
+
+            // Assert
+            response.StatusCode.Should().Be(System.Net.HttpStatusCode.BadRequest);
+            var errorResponse = await response.Content.ReadFromJsonAsync<ErrorResponseDto>();
+            errorResponse.Should().NotBeNull();
+            errorResponse?.Error.Should().Be("MISSING_CONDOMINIO_ID");
+            errorResponse?.Message.Should().Be("O CondominioId é obrigatório.");
+        }
+
+        [Fact]
+        public async Task Signup_WithEmptyCondominioId_ReturnsBadRequest()
+        {
+            // Arrange
+            var signupRequest = new SignupRequestDto
+            {
+                Nome = "Test User",
+                Email = $"testuser_{Guid.NewGuid()}@example.com",
+                Senha = "password123",
+                CondominioId = Guid.Empty, // Empty CondominioId
+                UnidadeId = Guid.NewGuid()
+            };
+
+            // Act
+            var response = await _client.PostAsJsonAsync("auth/signup", signupRequest);
+
+            // Assert
+            response.StatusCode.Should().Be(System.Net.HttpStatusCode.BadRequest);
+            var errorResponse = await response.Content.ReadFromJsonAsync<ErrorResponseDto>();
+            errorResponse.Should().NotBeNull();
+            errorResponse?.Error.Should().Be("MISSING_CONDOMINIO_ID");
+            errorResponse?.Message.Should().Be("O CondominioId é obrigatório.");
+        }
+
+        [Fact]
+        public async Task Signup_WithMissingUnidadeId_ReturnsBadRequest()
+        {
+            // Arrange
+            var signupRequest = new SignupRequestDto
+            {
+                Nome = "Test User",
+                Email = $"testuser_{Guid.NewGuid()}@example.com",
+                Senha = "password123",
+                CondominioId = Guid.NewGuid(),
+                UnidadeId = null // Missing UnidadeId
+            };
+
+            // Act
+            var response = await _client.PostAsJsonAsync("auth/signup", signupRequest);
+
+            // Assert
+            response.StatusCode.Should().Be(System.Net.HttpStatusCode.BadRequest);
+            var errorResponse = await response.Content.ReadFromJsonAsync<ErrorResponseDto>();
+            errorResponse.Should().NotBeNull();
+            errorResponse?.Error.Should().Be("MISSING_UNIDADE_ID");
+            errorResponse?.Message.Should().Be("O UnidadeId é obrigatório.");
+        }
+
+        [Fact]
+        public async Task Signup_WithEmptyUnidadeId_ReturnsBadRequest()
+        {
+            // Arrange
+            var signupRequest = new SignupRequestDto
+            {
+                Nome = "Test User",
+                Email = $"testuser_{Guid.NewGuid()}@example.com",
+                Senha = "password123",
+                CondominioId = Guid.NewGuid(),
+                UnidadeId = Guid.Empty // Empty UnidadeId
+            };
+
+            // Act
+            var response = await _client.PostAsJsonAsync("auth/signup", signupRequest);
+
+            // Assert
+            response.StatusCode.Should().Be(System.Net.HttpStatusCode.BadRequest);
+            var errorResponse = await response.Content.ReadFromJsonAsync<ErrorResponseDto>();
+            errorResponse.Should().NotBeNull();
+            errorResponse?.Error.Should().Be("MISSING_UNIDADE_ID");
+            errorResponse?.Message.Should().Be("O UnidadeId é obrigatório.");
         }
     }
 


### PR DESCRIPTION
This commit addresses an issue where user signup could lead to a 500 Internal Server Error. The root cause was that `CondominioId` and `UnidadeId`, which are non-nullable foreign keys for the `Usuario` entity, were not being supplied during signup. This led to attempts to save the new user with default `Guid.Empty` values for these IDs, causing database constraint violations.

Changes include:
- Modified `SignupRequestDto` to include `CondominioId` and `UnidadeId` as nullable Guids.
- Updated the `UsuariosController`'s `Signup` action to:
    - Require `CondominioId` and `UnidadeId` to be present and non-empty in the request.
    - Return a `400 Bad Request` with a specific error message if either ID is missing or Guid.Empty.
    - Assign the provided valid IDs to the new `Usuario` entity.
- Added new unit/integration tests to `AuthControllerTests.cs` to cover the new validation scenarios (missing/empty IDs).
- Updated existing signup tests to align with the new mandatory ID requirements.

These changes ensure that new users are always associated with a valid condominium and unit from the point of registration, preventing database errors and improving data integrity.