### PR TITLE
Fix signup Guid conversion in UsuariosController

### DIFF
--- a/conViver.API/Controllers/UsuariosController.cs
+++ b/conViver.API/Controllers/UsuariosController.cs
@@ -62,8 +62,8 @@ public class UsuariosController : ControllerBase // Renomear para AuthController
             Email = request.Email,
             SenhaHash = request.Senha, // O serviço _usuarios.AddAsync deve cuidar do hashing da senha
             Perfil = PerfilUsuario.Morador, // Perfil padrão, pode ser ajustado conforme regras de negócio
-            CondominioId = request.CondominioId, // Adicionado
-            UnidadeId = request.UnidadeId // Adicionado
+            CondominioId = request.CondominioId!.Value, // Garantido não nulo pelas validações
+            UnidadeId = request.UnidadeId!.Value // Garantido não nulo pelas validações
         };
         await _usuarios.AddAsync(usuario); // Assumindo que AddAsync faz o hash da senha
 


### PR DESCRIPTION
## Summary
- fix implicit conversions from `Guid?` to `Guid` in `UsuariosController`

## Testing
- `dotnet test` *(fails: `dotnet: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_6854c9025ff483329497be454bd1cc14