### PR TITLE
Add missing CondominioId column to Usuarios

### DIFF
--- a/DATABASE_SCHEMA.md
+++ b/DATABASE_SCHEMA.md
@@ -71,6 +71,9 @@ CREATE TABLE usuarios (
   perfil INTEGER NOT NULL, -- Enum PerfilUsuario (VARCHAR(20) no doc original)
   ativo BOOLEAN NOT NULL,
   two_fa_secret TEXT NULL, -- VARCHAR(32) no doc original
+  password_reset_token TEXT NULL,
+  password_reset_token_expiry TIMESTAMPTZ NULL,
+  condominio_id UUID NOT NULL REFERENCES condominios(id) ON DELETE CASCADE,
   unidade_id UUID NOT NULL REFERENCES unidades(id) ON DELETE CASCADE, -- Relacionamento direto
   created_at TIMESTAMPTZ NOT NULL,
   updated_at TIMESTAMPTZ NOT NULL

--- a/conViver.Infrastructure/Data/Contexts/DataSeeder.cs
+++ b/conViver.Infrastructure/Data/Contexts/DataSeeder.cs
@@ -53,7 +53,8 @@ public static class DataSeeder
                 Email = "admin@conviver.local",
                 SenhaHash = BCrypt.Net.BCrypt.HashPassword("admin123"),
                 Perfil = PerfilUsuario.Administrador,
-                UnidadeId = unidade.Id
+                UnidadeId = unidade.Id,
+                CondominioId = condominio.Id
             };
             db.Usuarios.Add(adminUser);
 
@@ -65,7 +66,8 @@ public static class DataSeeder
                 Email = "teste@conviver.local",
                 SenhaHash = BCrypt.Net.BCrypt.HashPassword("123456"),
                 Perfil = PerfilUsuario.Morador,
-                UnidadeId = unidade.Id
+                UnidadeId = unidade.Id,
+                CondominioId = condominio.Id
             };
             db.Usuarios.Add(testUser);
 

--- a/conViver.Infrastructure/Migrations/20250620015000_AddCondominioIdToUsuario.cs
+++ b/conViver.Infrastructure/Migrations/20250620015000_AddCondominioIdToUsuario.cs
@@ -1,0 +1,51 @@
+using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace conViver.Infrastructure.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddCondominioIdToUsuario : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<Guid>(
+                name: "CondominioId",
+                table: "Usuarios",
+                type: "TEXT",
+                nullable: false,
+                defaultValue: Guid.Empty);
+
+            migrationBuilder.CreateIndex(
+                name: "IX_Usuarios_CondominioId",
+                table: "Usuarios",
+                column: "CondominioId");
+
+            migrationBuilder.AddForeignKey(
+                name: "FK_Usuarios_Condominios_CondominioId",
+                table: "Usuarios",
+                column: "CondominioId",
+                principalTable: "Condominios",
+                principalColumn: "Id",
+                onDelete: ReferentialAction.Cascade);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropForeignKey(
+                name: "FK_Usuarios_Condominios_CondominioId",
+                table: "Usuarios");
+
+            migrationBuilder.DropIndex(
+                name: "IX_Usuarios_CondominioId",
+                table: "Usuarios");
+
+            migrationBuilder.DropColumn(
+                name: "CondominioId",
+                table: "Usuarios");
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- seed admin/test users with condo reference
- add migration to introduce `CondominioId` FK to `Usuarios`
- document extra columns in DATABASE_SCHEMA

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6854caa1a17483329fa170374e60fb48