### PR TITLE
Add troubleshooting note for missing CondominioId column

### DIFF
--- a/README.md
+++ b/README.md
@@ -207,6 +207,17 @@ O cliente móvel (`conViver.Mobile`) utiliza um serviço centralizado para feedb
 - Um indicador de carregamento global está definido em `AppShell.xaml` e é controlado pelo `FeedbackService`.
 - Mensagens de sucesso e informativas são exibidas usando `Snackbar` (do MAUI Community Toolkit). Erros críticos usam alertas modais.
 
+## Solução de Problemas Comuns
+
+### SQLite: "table Usuarios has no column named CondominioId"
+Esse erro indica que o arquivo `conviver.db` está desatualizado em relação às migrations. Execute:
+
+```bash
+dotnet ef database update --project src/conViver.Infrastructure
+```
+
+Se o problema continuar, remova `conviver.db` e rode o comando novamente para recriar o banco.
+
 ## Licença
 MIT
 


### PR DESCRIPTION
## Summary
- add a troubleshooting section in README about the SQLite error `table Usuarios has no column named CondominioId`

## Testing
- `dotnet test src/conViver.Tests/conViver.Tests.csproj --configuration Release --no-build` *(fails: `dotnet` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6854cc7a31ec833289335c061aff2710