### PR TITLE
Add SendToUser notification method

### DIFF
--- a/conViver.Core/Interfaces/INotificacaoService.cs
+++ b/conViver.Core/Interfaces/INotificacaoService.cs
@@ -8,6 +8,14 @@ public interface INotificacaoService
 {
     Task SendAsync(string destino, string mensagem, CancellationToken cancellationToken = default);
 
+    /// <summary>
+    /// Envia uma notificação diretamente para um usuário específico.
+    /// </summary>
+    /// <param name="usuarioId">Identificador do usuário destino.</param>
+    /// <param name="mensagem">Conteúdo da mensagem.</param>
+    /// <param name="cancellationToken">Token de cancelamento.</param>
+    Task SendToUserAsync(Guid usuarioId, string mensagem, CancellationToken cancellationToken = default);
+
     // Visitor Notifications
     Task NotificarChegadaVisitanteAsync(Guid unidadeId, string nomeVisitante, string? motivoVisita);
     Task NotificarVisitantePreAutorizadoAsync(Guid unidadeId, string nomeVisitante, string? qrCodeValue, DateTime? validadeQRCode);

--- a/conViver.Infrastructure/Notifications/NotificationService.cs
+++ b/conViver.Infrastructure/Notifications/NotificationService.cs
@@ -18,6 +18,12 @@ public class NotificationService : INotificacaoService
         return Task.CompletedTask;
     }
 
+    public Task SendToUserAsync(Guid usuarioId, string mensagem, CancellationToken cancellationToken = default)
+    {
+        string destino = $"user:{usuarioId}";
+        return SendAsync(destino, mensagem, cancellationToken);
+    }
+
     public Task NotificarChegadaVisitanteAsync(Guid unidadeId, string nomeVisitante, string? motivoVisita)
     {
         string mensagem = $"[NOTIFICACAO] Unidade {unidadeId}: Visitante '{nomeVisitante}' chegou.";


### PR DESCRIPTION
## Summary
- extend `INotificacaoService` with a new `SendToUserAsync` helper
- implement `SendToUserAsync` in `NotificationService`

## Testing
- `dotnet test conViver.Tests/conViver.Tests.csproj --verbosity minimal` *(fails: CS7036 in ReservasController)*

------
https://chatgpt.com/codex/tasks/task_e_685b534e2084833292076f214f5e6139