### PR TITLE
Fix build error in NotificationService

### DIFF
--- a/conViver.Infrastructure/Notifications/NotificationService.cs
+++ b/conViver.Infrastructure/Notifications/NotificationService.cs
@@ -67,4 +67,3 @@ public class NotificationService : INotificacaoService
     }
 
     }
-}


### PR DESCRIPTION
## Summary
- remove extra closing brace in `NotificationService` to fix CS1022

## Testing
- `dotnet build conViver.Infrastructure/conViver.Infrastructure.csproj`

------
https://chatgpt.com/codex/tasks/task_e_685b580173248332a4783164ba1a3a47