### PR TITLE
Fix tab visibility and clean styles

### DIFF
--- a/conViver.Web/css/styles.css
+++ b/conViver.Web/css/styles.css
@@ -845,14 +845,6 @@ main {
     /* border-top: none; */ /* Optional */
 }
 
-/* Ensure communication__title is styled if not already */
-/* This might already be covered by .db-section__title or similar, but let's ensure it has base styling */
-.communication__title {
-    font-size: var(--cv-font-size-h2, 1.75rem); /* Use variable or fallback */
-    margin-bottom: var(--cv-spacing-md, 15px); /* Use variable or fallback */
-    color: var(--current-text-primary);
-    font-weight: 600; /* From OpenSansSemibold */
-}
 
 /* Styles for new elements in Mural Digital */
 .sticky-notices-container {

--- a/conViver.Web/js/comunicacao.js
+++ b/conViver.Web/js/comunicacao.js
@@ -72,7 +72,6 @@ document.addEventListener('DOMContentLoaded', async () => {
 function setupTabs() {
     const tabButtons = document.querySelectorAll('.cv-tab-button');
     const tabContents = document.querySelectorAll('.cv-tab-content');
-    const muralContent = document.getElementById('content-mural');
     const globalCategoryFilter = document.getElementById('category-filter-modal');
 
     const userRoles = getUserRoles();
@@ -84,15 +83,13 @@ function setupTabs() {
 
     tabButtons.forEach(button => {
         button.addEventListener('click', () => {
-            tabContents.forEach(content => {
-                if (content.id !== 'content-mural') {
-                    content.style.display = 'none';
-                }
-            });
             tabButtons.forEach(btn => btn.classList.remove('active'));
             button.classList.add('active');
 
-            if (muralContent) muralContent.style.display = 'block';
+            tabContents.forEach(content => {
+                const targetId = 'content-' + button.id.replace('tab-', '');
+                content.style.display = content.id === targetId ? 'block' : 'none';
+            });
 
             let categoryToSetInGlobalFilter = '';
             if (button.id === 'tab-enquetes') {

--- a/conViver.Web/wwwroot/css/styles.css
+++ b/conViver.Web/wwwroot/css/styles.css
@@ -837,14 +837,6 @@ main {
     /* border-top: none; */ /* Optional */
 }
 
-/* Ensure communication__title is styled if not already */
-/* This might already be covered by .db-section__title or similar, but let's ensure it has base styling */
-.communication__title {
-    font-size: var(--cv-font-size-h2, 1.75rem); /* Use variable or fallback */
-    margin-bottom: var(--cv-spacing-md, 15px); /* Use variable or fallback */
-    color: var(--current-text-primary);
-    font-weight: 600; /* From OpenSansSemibold */
-}
 
 /* Styles for new elements in Mural Digital */
 .sticky-notices-container {


### PR DESCRIPTION
## Summary
- ensure tab switching hides other sub-tabs in Comunicação
- remove unused `.communication__title` style

## Testing
- `dotnet test --no-build --verbosity minimal` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685b5eb0bbc08332b33115fb00969133