### PR TITLE
Refactor communication module to implement dynamic feed and integrate…

### DIFF
--- a/conViver.Web/wwwroot/pages/comunicacao.html
+++ b/conViver.Web/wwwroot/pages/comunicacao.html
@@ -26,6 +26,45 @@
         .icon-button:hover {
             color: var(--current-primary-blue);
         }
+        .feed-item.prio-0 {
+            background-color: var(--current-highlight-bg, #fff amarillo); /* Light yellow, fallback to a variable */
+            border-left: 5px solid var(--current-primary-blue, #007bff); /* Accent border */
+        }
+        .feed-item__pin {
+            display: inline-block;
+            background-color: var(--current-primary-blue, #007bff);
+            color: white;
+            padding: 2px 8px;
+            border-radius: 4px;
+            font-size: 0.8em;
+            margin-right: 8px;
+            font-weight: bold;
+        }
+        .enquete-resultado-opcao {
+            margin-bottom: 10px;
+        }
+        .progress-bar-container {
+            background-color: #e0e0e0;
+            border-radius: 4px;
+            height: 20px;
+            overflow: hidden;
+            margin-top: 4px;
+        }
+        .progress-bar {
+            background-color: var(--current-primary-blue, #007bff);
+            height: 100%;
+            line-height: 20px; /* For potential text inside */
+            color: white;
+            text-align: right;
+            padding-right: 5px;
+            box-sizing: border-box;
+            transition: width 0.5s ease-in-out;
+        }
+        .cv-radio-option {
+            display: block;
+            margin-bottom: 8px;
+            cursor: pointer;
+        }
     </style>
 </head>
 <body>


### PR DESCRIPTION
… Enquetes/Chamados modals

- Implemented infinite scrolling for the main feed on 'comunicacao.html'.
- Integrated sticky items (urgent notices, active polls, etc.) at the top of the feed.
- Refactored tab behavior: 'Mural', 'Enquetes', 'Solicitações' tabs now filter the main feed.
- Enquetes:
    - Creation via modal, calls API.
    - Clicking feed item opens detail modal for viewing options, voting, or seeing results (text/simple progress bars).
- Chamados (Solicitações):
    - Creation via modal, calls API (supports basic FormData for attachments).
    - Clicking feed item opens detail modal showing information.
    - Síndico can update status and add response via the detail modal.
    - User comment functionality in modal is stubbed pending specific backend endpoint.
- Ensured filter icon opens filter modal; removed redundant elements.
- Added basic CSS for sticky items and poll results.
- Analyzed backend capabilities and identified areas for future enhancement (e.g., specific 'add comment' endpoint for chamados, 'edit poll' endpoint).