### PR TITLE
Add skeleton loading to communication tabs

### DIFF
--- a/conViver.Web/css/components.css
+++ b/conViver.Web/css/components.css
@@ -497,3 +497,41 @@ html[data-theme="dark"] .cv-nav__link:hover {
     width: 100%;
 }
 
+/* Skeleton Screen Components */
+.feed-skeleton-item {
+    padding: var(--cv-spacing-md);
+    border-radius: var(--cv-border-radius-md);
+    border: 1px solid var(--current-border-subtle, #eee);
+    margin-bottom: var(--cv-spacing-md);
+    position: relative;
+    overflow: hidden;
+}
+.skeleton-title,
+.skeleton-line {
+    background-color: var(--cv-gray-200);
+    border-radius: 4px;
+    height: 16px;
+    margin-bottom: 8px;
+}
+.skeleton-title {
+    width: 60%;
+    height: 20px;
+}
+.skeleton-line.short {
+    width: 80%;
+}
+.feed-skeleton-item::after {
+    content: '';
+    position: absolute;
+    top: 0;
+    left: -150px;
+    height: 100%;
+    width: 150px;
+    background: linear-gradient(90deg, transparent, rgba(255,255,255,0.6), transparent);
+    animation: skeleton-shimmer 1.2s infinite;
+}
+@keyframes skeleton-shimmer {
+    0% { transform: translateX(0); }
+    100% { transform: translateX(100%); }
+}
+

--- a/conViver.Web/css/styles.css
+++ b/conViver.Web/css/styles.css
@@ -777,6 +777,11 @@ main {
     height: 40px;
     animation: spin 1s linear infinite;
 }
+.spinner.spinner-small {
+    width: 20px;
+    height: 20px;
+    border-width: 2px;
+}
 
 @keyframes spin {
     0% { transform: rotate(0deg); }

--- a/conViver.Web/js/comunicacao.js
+++ b/conViver.Web/js/comunicacao.js
@@ -9,6 +9,28 @@ let noMoreFeedItems = false;
 const feedContainerSelector = ".js-avisos";
 const feedScrollSentinelId = "notice-scroll-sentinel";
 let fetchedFeedItems = [];
+const skeletonCount = 3;
+
+function showFeedSkeleton() {
+  const container = document.querySelector(feedContainerSelector);
+  if (!container) return;
+  hideFeedSkeleton();
+  const sentinel = document.getElementById(feedScrollSentinelId);
+  for (let i = 0; i < skeletonCount; i++) {
+    const card = document.createElement("div");
+    card.className = "cv-card feed-skeleton-item";
+    card.innerHTML =
+      '<div class="skeleton-title"></div>' +
+      '<div class="skeleton-line"></div>' +
+      '<div class="skeleton-line short"></div>';
+    if (sentinel) container.insertBefore(card, sentinel);
+    else container.appendChild(card);
+  }
+}
+
+function hideFeedSkeleton() {
+  document.querySelectorAll(".feed-skeleton-item").forEach((el) => el.remove());
+}
 
 // Modals
 let criarAvisoModal, formCriarAviso, avisoIdField;
@@ -658,6 +680,8 @@ async function loadInitialFeedItems() {
   }
   sentinel.style.display = "block";
 
+  showFeedSkeleton();
+
   await fetchAndDisplayFeedItems(currentFeedPage, false);
 }
 function setupFeedObserver() {
@@ -720,7 +744,7 @@ async function fetchAndDisplayFeedItems(page, append = false) {
       if (sentinelElement) container.insertBefore(loadingP, sentinelElement);
       else container.appendChild(loadingP);
     }
-    loadingP.textContent = "Carregando feed...";
+    loadingP.innerHTML = '<span class="spinner spinner-small"></span> Carregando feed...';
     loadingP.style.display = "block";
   } else {
     if (
@@ -732,7 +756,7 @@ async function fetchAndDisplayFeedItems(page, append = false) {
       container.insertBefore(loadingP, sentinelElement);
     }
     if (loadingP) {
-      loadingP.textContent = "Carregando mais itens...";
+      loadingP.innerHTML = '<span class="spinner spinner-small"></span> Carregando mais itens...';
       loadingP.style.display = "block";
     }
   }
@@ -768,6 +792,7 @@ async function fetchAndDisplayFeedItems(page, append = false) {
     const items = response || [];
 
     if (loadingP) loadingP.style.display = "none";
+    hideFeedSkeleton();
 
     if (items.length > 0) {
       items.forEach((item) => {
@@ -840,6 +865,7 @@ async function fetchAndDisplayFeedItems(page, append = false) {
   } catch (error) {
     console.error("Erro ao buscar feed:", error);
     if (loadingP) loadingP.style.display = "none";
+    hideFeedSkeleton();
 
     const currentVisibleItemsOnError = container.querySelectorAll(".feed-item");
     if (currentVisibleItemsOnError.length === 0) {
@@ -857,6 +883,7 @@ async function fetchAndDisplayFeedItems(page, append = false) {
     if (sentinelElement) sentinelElement.style.display = "none";
   } finally {
     isLoadingFeedItems = false;
+    hideFeedSkeleton();
   }
 }
 
@@ -1066,7 +1093,7 @@ async function handleEnqueteClick(itemId, targetElementOrCard) {
   if (!modalEnqueteDetalhe || !apiClient) return;
 
   modalEnqueteDetalheOpcoesContainer.innerHTML =
-    '<p class="cv-loading-message">Carregando detalhes da enquete...</p>';
+    '<p class="cv-loading-message"><span class="spinner spinner-small"></span> Carregando detalhes da enquete...</p>';
   modalEnqueteDetalheStatus.innerHTML = "";
   modalEnqueteSubmitVotoButton.style.display = "none";
   modalEnqueteDetalhe.style.display = "flex";
@@ -1210,7 +1237,7 @@ async function handleChamadoClick(
   if (!modalChamadoDetalhe || !apiClient) return;
 
   modalChamadoDetalheConteudo.innerHTML =
-    '<p class="cv-loading-message">Carregando detalhes...</p>';
+    '<p class="cv-loading-message"><span class="spinner spinner-small"></span> Carregando detalhes...</p>';
   modalChamadoDetalheInteracoes.innerHTML = "";
 
   const sindicoUpdateSection = document.getElementById(

--- a/conViver.Web/pages/comunicacao.html
+++ b/conViver.Web/pages/comunicacao.html
@@ -35,6 +35,8 @@
 </head>
 
 <body>
+    <div id="global-loading-overlay" class="loading-overlay"><div class="spinner"></div></div>
+    <div id="global-message-banner" class="message-banner"></div>
     <header class="cv-header">
         <div class="cv-container cv-header__container">
             <h1 class="cv-header__title">conViver</h1>

--- a/conViver.Web/wwwroot/css/components.css
+++ b/conViver.Web/wwwroot/css/components.css
@@ -497,3 +497,41 @@ html[data-theme="dark"] .cv-nav__link:hover {
     width: 100%;
 }
 
+/* Skeleton Screen Components */
+.feed-skeleton-item {
+    padding: var(--cv-spacing-md);
+    border-radius: var(--cv-border-radius-md);
+    border: 1px solid var(--current-border-subtle, #eee);
+    margin-bottom: var(--cv-spacing-md);
+    position: relative;
+    overflow: hidden;
+}
+.skeleton-title,
+.skeleton-line {
+    background-color: var(--cv-gray-200);
+    border-radius: 4px;
+    height: 16px;
+    margin-bottom: 8px;
+}
+.skeleton-title {
+    width: 60%;
+    height: 20px;
+}
+.skeleton-line.short {
+    width: 80%;
+}
+.feed-skeleton-item::after {
+    content: '';
+    position: absolute;
+    top: 0;
+    left: -150px;
+    height: 100%;
+    width: 150px;
+    background: linear-gradient(90deg, transparent, rgba(255,255,255,0.6), transparent);
+    animation: skeleton-shimmer 1.2s infinite;
+}
+@keyframes skeleton-shimmer {
+    0% { transform: translateX(0); }
+    100% { transform: translateX(100%); }
+}
+

--- a/conViver.Web/wwwroot/css/styles.css
+++ b/conViver.Web/wwwroot/css/styles.css
@@ -211,6 +211,14 @@ html[data-theme="dark"] {
     --current-nav-bg: var(--cv-dark-bg-element); /* Match element bg for dark nav */
 }
 
+html[data-theme="dark"] .feed-item.prio-0 {
+    background-color: var(--cv-dark-gray-300); /* Um pouco mais claro que o fundo do card normal no escuro */
+    border-left-color: var(--cv-dark-primary-orange); /* Usar a versão escura da cor laranja */
+}
+/* O ::before do feed-item.prio-0 (emoji) geralmente se adapta bem, mas se precisar de ajuste: */
+/* html[data-theme="dark"] .feed-item.prio-0::before { color: var(--some-dark-theme-emoji-color); } */
+
+
 body {
     font-family: var(--cv-font-family-sans-serif);
     margin: 0;
@@ -769,6 +777,11 @@ main {
     height: 40px;
     animation: spin 1s linear infinite;
 }
+.spinner.spinner-small {
+    width: 20px;
+    height: 20px;
+    border-width: 2px;
+}
 
 @keyframes spin {
     0% { transform: rotate(0deg); }
@@ -915,6 +928,7 @@ main {
     transform: translateY(0px); /* Press down effect */
 }
 
+/* Container e menu de opções do FAB */
 .fab-menu {
     position: fixed;
     bottom: var(--cv-spacing-lg, 20px);
@@ -1478,10 +1492,144 @@ html[data-theme="dark"] .cv-modal-close {
     position: absolute;
     left: 5px;
     top: 5px;
+    font-size: 1.2em; /* Ajustar tamanho do emoji se necessário */
 }
 
 .feed-item__pin {
     font-size: 0.85em;
     color: var(--cv-primary-orange);
     margin-right: 4px;
+}
+
+/* Feed Item Chip/Tag Styles */
+.feed-item__tags {
+    margin-top: var(--cv-spacing-sm);
+    display: flex;
+    flex-wrap: wrap;
+    gap: var(--cv-spacing-xs);
+}
+
+.feed-item__tag {
+    background-color: var(--cv-gray-200);
+    color: var(--cv-gray-700);
+    padding: var(--cv-spacing-xs) var(--cv-spacing-sm);
+    border-radius: var(--cv-border-radius-sm);
+    font-size: 0.75rem;
+    font-weight: 500;
+    text-transform: uppercase; /* Opcional */
+}
+
+html[data-theme="dark"] .feed-item__tag {
+    background-color: var(--cv-dark-gray-400);
+    color: var(--cv-dark-gray-900);
+}
+
+/* Example of type-specific tag colors (optional) */
+.feed-item__tag--aviso { background-color: var(--cv-primary-blue); color: white; }
+.feed-item__tag--enquete { background-color: var(--cv-primary-green); color: white; }
+.feed-item__tag--chamado { background-color: var(--cv-primary-orange); color: white; }
+.feed-item__tag--documento { background-color: var(--cv-gray-500); color: white; }
+
+html[data-theme="dark"] .feed-item__tag--aviso { background-color: var(--cv-dark-primary-blue); }
+html[data-theme="dark"] .feed-item__tag--enquete { background-color: var(--cv-dark-primary-green); }
+html[data-theme="dark"] .feed-item__tag--chamado { background-color: var(--cv-dark-primary-orange); }
+/* Note: Dark theme for 'documento' tag might need a different dark gray if cv-gray-500 is too light on dark bg */
+html[data-theme="dark"] .feed-item__tag--documento { background-color: var(--cv-dark-gray-500); }
+
+
+/* Biblioteca de Documentos Styles */
+.cv-page-title { /* Estilo para o título principal da página, como "Biblioteca de Documentos" */
+    font-size: var(--cv-font-size-h2, 1.75rem);
+    margin-bottom: var(--cv-spacing-lg, 20px);
+    color: var(--current-text-primary);
+    font-weight: 600;
+    padding-bottom: var(--cv-spacing-sm);
+    border-bottom: 1px solid var(--current-border-subtle);
+}
+
+.cv-section--actions { /* Para a seção de filtros e botão de upload */
+    display: flex;
+    flex-wrap: wrap;
+    gap: var(--cv-spacing-md);
+    align-items: center;
+    margin-bottom: var(--cv-spacing-lg);
+    padding: var(--cv-spacing-md);
+    background-color: var(--current-bg-white);
+    border-radius: var(--cv-border-radius-md);
+    box-shadow: var(--current-shadow-sm);
+}
+.cv-section--actions .cv-input,
+.cv-section--actions .cv-button {
+    flex-grow: 1; /* Inputs e botões podem crescer */
+}
+@media (min-width: 768px) {
+    .cv-section--actions .cv-input,
+    .cv-section--actions .cv-button {
+        flex-grow: 0; /* Não crescer demais em telas maiores */
+        min-width: 200px; /* Largura mínima */
+    }
+}
+
+
+.document-list {
+    display: grid;
+    grid-template-columns: repeat(auto-fill, minmax(300px, 1fr)); /* Layout responsivo em grid */
+    gap: var(--cv-spacing-md);
+}
+
+.document-item { /* Estilo para cada card de documento - usa .cv-card como base */
+    /* .cv-card já fornece background, border, padding, shadow */
+    display: flex;
+    flex-direction: column;
+    justify-content: space-between; /* Para alinhar ações na parte inferior */
+}
+
+.document-item__info {
+    margin-bottom: var(--cv-spacing-sm);
+}
+
+.document-item__title {
+    font-size: var(--cv-font-size-lg); /* 1.125rem */
+    font-weight: 600;
+    color: var(--current-text-primary);
+    margin-bottom: var(--cv-spacing-xs);
+}
+
+.document-item__meta {
+    font-size: 0.85rem;
+    color: var(--current-text-secondary);
+    line-height: 1.4;
+}
+.document-item__meta span {
+    display: block; /* Cada meta info em uma nova linha, ou usar flex/grid para layout em linha */
+    margin-bottom: 2px;
+}
+
+.document-item__actions {
+    margin-top: auto; /* Empurra as ações para o final do card se o card tiver altura variável */
+    padding-top: var(--cv-spacing-sm);
+    border-top: 1px solid var(--current-border-subtle);
+    display: flex;
+    justify-content: flex-end; /* Alinha botões à direita */
+    gap: var(--cv-spacing-sm);
+}
+.document-item__actions .cv-button {
+    font-size: 0.9rem; /* Botões de ação um pouco menores */
+    padding: var(--cv-spacing-xs) var(--cv-spacing-sm);
+}
+
+
+/* Estilos para o modal de upload de documentos, se necessário além do .cv-modal */
+#formUploadDocumento .cv-form-group {
+    margin-bottom: var(--cv-spacing-md);
+}
+#formUploadDocumento label {
+    display: block;
+    margin-bottom: var(--cv-spacing-xs);
+    font-weight: 500;
+    color: var(--current-text-secondary);
+}
+#formUploadDocumento .cv-input { /* Garante que inputs dentro do form do modal usem o estilo global */
+    width: 100%;
+    box-sizing: border-box;
 }

--- a/conViver.Web/wwwroot/js/comunicacao.js
+++ b/conViver.Web/wwwroot/js/comunicacao.js
@@ -9,6 +9,28 @@ let noMoreFeedItems = false;
 const feedContainerSelector = ".js-avisos";
 const feedScrollSentinelId = "notice-scroll-sentinel";
 let fetchedFeedItems = [];
+const skeletonCount = 3;
+
+function showFeedSkeleton() {
+  const container = document.querySelector(feedContainerSelector);
+  if (!container) return;
+  hideFeedSkeleton();
+  const sentinel = document.getElementById(feedScrollSentinelId);
+  for (let i = 0; i < skeletonCount; i++) {
+    const card = document.createElement("div");
+    card.className = "cv-card feed-skeleton-item";
+    card.innerHTML =
+      '<div class="skeleton-title"></div>' +
+      '<div class="skeleton-line"></div>' +
+      '<div class="skeleton-line short"></div>';
+    if (sentinel) container.insertBefore(card, sentinel);
+    else container.appendChild(card);
+  }
+}
+
+function hideFeedSkeleton() {
+  document.querySelectorAll(".feed-skeleton-item").forEach((el) => el.remove());
+}
 
 // Modals
 let criarAvisoModal, formCriarAviso, avisoIdField;
@@ -658,6 +680,8 @@ async function loadInitialFeedItems() {
   }
   sentinel.style.display = "block";
 
+  showFeedSkeleton();
+
   await fetchAndDisplayFeedItems(currentFeedPage, false);
 }
 function setupFeedObserver() {
@@ -720,7 +744,7 @@ async function fetchAndDisplayFeedItems(page, append = false) {
       if (sentinelElement) container.insertBefore(loadingP, sentinelElement);
       else container.appendChild(loadingP);
     }
-    loadingP.textContent = "Carregando feed...";
+    loadingP.innerHTML = '<span class="spinner spinner-small"></span> Carregando feed...';
     loadingP.style.display = "block";
   } else {
     if (
@@ -732,7 +756,7 @@ async function fetchAndDisplayFeedItems(page, append = false) {
       container.insertBefore(loadingP, sentinelElement);
     }
     if (loadingP) {
-      loadingP.textContent = "Carregando mais itens...";
+      loadingP.innerHTML = '<span class="spinner spinner-small"></span> Carregando mais itens...';
       loadingP.style.display = "block";
     }
   }
@@ -768,6 +792,7 @@ async function fetchAndDisplayFeedItems(page, append = false) {
     const items = response || [];
 
     if (loadingP) loadingP.style.display = "none";
+    hideFeedSkeleton();
 
     if (items.length > 0) {
       items.forEach((item) => {
@@ -840,6 +865,7 @@ async function fetchAndDisplayFeedItems(page, append = false) {
   } catch (error) {
     console.error("Erro ao buscar feed:", error);
     if (loadingP) loadingP.style.display = "none";
+    hideFeedSkeleton();
 
     const currentVisibleItemsOnError = container.querySelectorAll(".feed-item");
     if (currentVisibleItemsOnError.length === 0) {
@@ -857,6 +883,7 @@ async function fetchAndDisplayFeedItems(page, append = false) {
     if (sentinelElement) sentinelElement.style.display = "none";
   } finally {
     isLoadingFeedItems = false;
+    hideFeedSkeleton();
   }
 }
 
@@ -1066,7 +1093,7 @@ async function handleEnqueteClick(itemId, targetElementOrCard) {
   if (!modalEnqueteDetalhe || !apiClient) return;
 
   modalEnqueteDetalheOpcoesContainer.innerHTML =
-    '<p class="cv-loading-message">Carregando detalhes da enquete...</p>';
+    '<p class="cv-loading-message"><span class="spinner spinner-small"></span> Carregando detalhes da enquete...</p>';
   modalEnqueteDetalheStatus.innerHTML = "";
   modalEnqueteSubmitVotoButton.style.display = "none";
   modalEnqueteDetalhe.style.display = "flex";
@@ -1210,7 +1237,7 @@ async function handleChamadoClick(
   if (!modalChamadoDetalhe || !apiClient) return;
 
   modalChamadoDetalheConteudo.innerHTML =
-    '<p class="cv-loading-message">Carregando detalhes...</p>';
+    '<p class="cv-loading-message"><span class="spinner spinner-small"></span> Carregando detalhes...</p>';
   modalChamadoDetalheInteracoes.innerHTML = "";
 
   const sindicoUpdateSection = document.getElementById(

--- a/conViver.Web/wwwroot/pages/comunicacao.html
+++ b/conViver.Web/wwwroot/pages/comunicacao.html
@@ -35,6 +35,8 @@
 </head>
 
 <body>
+    <div id="global-loading-overlay" class="loading-overlay"><div class="spinner"></div></div>
+    <div id="global-message-banner" class="message-banner"></div>
     <header class="cv-header">
         <div class="cv-container cv-header__container">
             <h1 class="cv-header__title">conViver</h1>


### PR DESCRIPTION
## Summary
- add spinner variants
- create skeleton card styles
- add global loading overlay to communication page
- implement skeleton screen logic in JS
- sync built assets in `wwwroot`

## Testing
- `dotnet format conViver.sln --no-restore`
- `dotnet test --no-build`
- `./scripts/sync_wwwroot.sh`

------
https://chatgpt.com/codex/tasks/task_e_685c94e0cb148332b93ee88a328a2a2d