### PR TITLE
Fix Reservas tabs and calendar

### DIFF
--- a/conViver.Web/js/reservas.js
+++ b/conViver.Web/js/reservas.js
@@ -1,11 +1,15 @@
 import { showGlobalFeedback } from "./main.js";
 import { requireAuth, getUserInfo, getRoles } from "./auth.js";
 import apiClient from "./apiClient.js";
-import FullCalendar from "@fullcalendar/core";
-import dayGridPlugin from "@fullcalendar/daygrid";
-import timeGridPlugin from "@fullcalendar/timegrid";
-import listPlugin from "@fullcalendar/list";
-import ptBrLocale from "@fullcalendar/core/locales/pt-br";
+// FullCalendar is loaded globally via CDN in reservas.html. Here we pull the
+// needed constructors/plugins from the global object to avoid module
+// resolution issues when running without a bundler.
+const {
+  Calendar: FullCalendarCalendar,
+  dayGridPlugin,
+  timeGridPlugin,
+  listPlugin,
+} = window.FullCalendar || {};
 
 let espacosComunsList = [];
 let calendarioReservas = null;
@@ -1068,8 +1072,13 @@ function initializeFullCalendar() {
     console.error("Elemento #calendario-reservas não encontrado.");
     return;
   }
-  calendarioReservas = new FullCalendar.Calendar(el, {
-    locale: ptBrLocale,
+  if (!FullCalendarCalendar) {
+    console.error("FullCalendar library not loaded.");
+    return;
+  }
+
+  calendarioReservas = new FullCalendarCalendar(el, {
+    locale: "pt-br",
     plugins: [dayGridPlugin, timeGridPlugin, listPlugin],
     initialView: "dayGridMonth",
     headerToolbar: {


### PR DESCRIPTION
## Summary
- use global FullCalendar object instead of npm-style imports
- guard calendar initialization when FullCalendar is missing

## Testing
- `node -c conViver.Web/js/reservas.js`
- `dotnet test --no-build` *(fails: `dotnet` not found)*

------
https://chatgpt.com/codex/tasks/task_e_685d77ab92b88332be2e0f939b739970