### PR TITLE
Refactor: Consolidate Reserva Filters and Enhance List Views

### DIFF
--- a/conViver.Web/wwwroot/pages/reservas.html
+++ b/conViver.Web/wwwroot/pages/reservas.html
@@ -151,15 +151,10 @@
                 <section class="reservas-section cv-card">
                     <h2 class="cv-section__title">Agenda e Disponibilidade</h2>
                     <div class="reservas-filtros-container">
-                        <div class="cv-form-group">
-                            <label for="select-espaco-comum-calendario">Filtrar por Espaço Comum:</label>
-                            <select id="select-espaco-comum-calendario" class="cv-input">
-                                <option value="">Todos os Espaços</option>
-                            </select>
-                        </div>
+                        /* Espaço Comum filter removed, now handled by unified modal */
                         <div id="filtros-reservas-admin-calendario" class="cv-form" style="flex-basis: 100%; display:flex; gap: var(--cv-spacing-md); flex-wrap: wrap; align-items: flex-end; display: none;">
                             <div class="cv-form-group">
-                                <label for="filtro-status-reserva-calendario">Status:</label>
+                                <label for="filtro-status-reserva-calendario">Status (Admin):</label>
                                 <select id="filtro-status-reserva-calendario" class="cv-input">
                                     <option value="">Todos</option>
                                     <option value="Pendente">Pendente</option>
@@ -185,31 +180,7 @@
             <div id="list-view-container" style="display:none;">
                 <section class="reservas-section cv-card">
                     <h2 class="cv-section__title">Lista de Reservas</h2>
-                    <div class="reservas-filtros-container">
-                        <div class="cv-form-group">
-                            <label for="filtro-espaco-lista">Espaço Comum:</label>
-                            <select id="filtro-espaco-lista" class="cv-input">
-                                <option value="">Todos</option>
-                                <!-- Populado por JS -->
-                            </select>
-                        </div>
-                        <div class="cv-form-group">
-                            <label for="filtro-status-lista">Status:</label>
-                            <select id="filtro-status-lista" class="cv-input">
-                                <option value="">Todos</option>
-                                <option value="Pendente">Pendente</option>
-                                <option value="Confirmada">Confirmada</option>
-                                <option value="Recusada">Recusada</option>
-                                <option value="CanceladaPeloUsuario">Cancelada</option> <!-- Simplificado para o usuário -->
-                                <!-- <option value="CanceladaPeloSindico">Cancelada pelo Síndico</option> -->
-                            </select>
-                        </div>
-                        <div class="cv-form-group">
-                            <label for="filtro-periodo-lista">Período:</label>
-                            <input type="month" id="filtro-periodo-lista" class="cv-input">
-                        </div>
-                        <button id="btn-aplicar-filtros-lista" class="cv-button cv-button--primary">Filtrar Lista</button>
-                    </div>
+                    <!-- Filtros locais removidos, agora controlados pelo modal de filtros unificados -->
                     <div id="list-view-reservas-items" style="margin-top: var(--cv-spacing-lg);">
                         <!-- Cards de reserva serão inseridos aqui por JS -->
                         <p class="cv-loading-message">Carregando lista de reservas...</p>
@@ -223,32 +194,11 @@
         <div class="cv-tab-content" id="content-minhas-reservas" style="display:none;">
             <section class="reservas-section cv-card">
                 <h2 class="cv-section__title">Minhas Reservas</h2>
-                <div class="reservas-filtros-container">
-                    <div class="cv-form-group">
-                        <label for="filtro-minhas-espaco">Espaço Comum:</label>
-                        <select id="filtro-minhas-espaco" class="cv-input">
-                            <option value="">Todos</option>
-                        </select>
-                    </div>
-                    <div class="cv-form-group">
-                        <label for="filtro-minhas-status">Status:</label>
-                        <select id="filtro-minhas-status" class="cv-input">
-                            <option value="">Todos</option>
-                            <option value="Pendente">Pendente</option>
-                            <option value="Confirmada">Confirmada</option>
-                            <option value="Recusada">Recusada</option>
-                            <option value="CanceladaPeloUsuario">Cancelada</option>
-                        </select>
-                    </div>
-                    <div class="cv-form-group">
-                        <label for="filtro-minhas-periodo">Período:</label>
-                        <input type="month" id="filtro-minhas-periodo" class="cv-input">
-                    </div>
-                    <button id="btn-aplicar-filtros-minhas" class="cv-button cv-button--primary">Filtrar</button>
-                </div>
+                <!-- Filtros locais removidos, agora controlados pelo modal de filtros unificados -->
                 <div id="minhas-reservas-list" class="minhas-reservas-list">
                     <p class="cv-loading-message">Carregando suas reservas...</p>
                 </div>
+                <div id="minhas-reservas-list-sentinel" style="height: 10px; width: 100%;"></div>
             </section>
         </div>
 
@@ -285,15 +235,28 @@
                 <div class="cv-form-group">
                     <label for="filtro-espaco-modal-reservas">Espaço:</label>
                     <select id="filtro-espaco-modal-reservas" class="cv-input">
-                        <option value="">Todos</option>
-                        <option value="salao">Salão de Festas</option>
-                        <option value="churrasqueira">Churrasqueira</option>
-                        <option value="quadra">Quadra</option>
-                        <option value="coworking">Coworking</option>
+                        <option value="">Todos os Espaços</option>
+                        <!-- Options will be populated by carregarEspacosComuns -->
                     </select>
+                </div>
+                <div class="cv-form-group">
+                    <label for="filtro-status-modal-reservas">Status:</label>
+                    <select id="filtro-status-modal-reservas" class="cv-input">
+                        <option value="">Todos os Status</option>
+                        <option value="Pendente">Pendente</option>
+                        <option value="Confirmada">Confirmada</option>
+                        <option value="Recusada">Recusada</option>
+                        <option value="CanceladaPeloUsuario">Cancelada pelo Usuário</option>
+                        <option value="CanceladaPeloSindico">Cancelada pelo Síndico</option>
+                    </select>
+                </div>
+                <div class="cv-form-group">
+                    <label for="filtro-periodo-modal-reservas">Período (Mês/Ano):</label>
+                    <input type="month" id="filtro-periodo-modal-reservas" class="cv-input">
                 </div>
                 <div class="cv-form-actions">
                     <button id="aplicar-filtros-modal-reservas" class="cv-button cv-button--primary">Aplicar Filtros</button>
+                    <button id="limpar-filtros-modal-reservas" type="button" class="cv-button cv-button--secondary" style="margin-left: 8px;">Limpar</button>
                     <button type="button" class="cv-button js-modal-filtros-reservas-close">Cancelar</button>
                 </div>
             </div>


### PR DESCRIPTION
This commit refactors the reservations page (/pages/reservas.html and js/reservas.js) to improve filter functionality and list views.

Key changes:
- Unified Filter Modal:
  - Expanded the main filter modal to include 'Espaço Comum', 'Status', and 'Período' (Month/Year).
  - This modal is now the primary source of filters for all reservation views (Calendar, Agenda List, Minhas Reservas List).
  - Added a 'Limpar Filtros' button to the modal.
- Data fetching functions (`initializeFullCalendar` events, `carregarReservasListView`, `carregarMinhasReservas`) updated to use the unified filters from this modal.
- Removed redundant local filter UI elements from the Calendar (partially), Agenda List, and Minhas Reservas views to streamline the interface.
- Corresponding JavaScript logic for old local filters (declarations, DOM lookups, event listeners) has been removed or updated.

'Agenda e Disponibilidade' Tab:
- `carregarReservasListView` now fetches data from the API (was previously mock data) and uses unified filters.
- FullCalendar views ('listDay', 'listWeek', 'listMonth') are available in the header, providing continuous list view options.

'Minhas Reservas' Tab:
- Implemented `carregarMinhasReservas` function (was missing). It uses unified filters and is prepared for API data (currently uses mock data for testing).
- Implemented infinite scroll for the 'Minhas Reservas' list.

Styling and HTML:
- Minor HTML adjustments for new modal fields and sentinel elements.
- Removed old filter container divs.
- Assumed existing CSS handles new modal elements adequately.