### PR TITLE
Adiciona logs em fabMenu.js para diagnosticar problema de visibilidade

### DIFF
--- a/conViver.Web/css/styles.css
+++ b/conViver.Web/css/styles.css
@@ -973,12 +973,9 @@ html[data-theme="dark"] .fab-menu-options {
 .fab-menu-options .cv-button:last-child {
     margin-bottom: 0;
 }
-.fab-menu--open .fab-menu-options {
-    display: flex;
-}
-.fab-menu-options .cv-button {
-    width: 160px;
-}
+/* .fab-menu--open .fab-menu-options { display: flex; } está definido acima e é suficiente */
+/* Removida regra duplicada/conflitante abaixo: */
+/* .fab-menu-options .cv-button { width: 160px; } */
 
 
 /* Helper class for loading messages if not already present */

--- a/conViver.Web/js/fabMenu.js
+++ b/conViver.Web/js/fabMenu.js
@@ -1,5 +1,9 @@
 export function initFabMenu(actions = []) {
-    if (!actions || actions.length === 0) return;
+    console.log("[fabMenu.js] initFabMenu chamado com actions:", actions); // Log para diagnóstico
+    if (!actions || actions.length === 0) {
+        console.warn("[fabMenu.js] Nenhuma ação fornecida, FAB não será criado.");
+        return;
+    }
 
     const container = document.createElement('div');
     container.className = 'fab-menu';
@@ -38,5 +42,7 @@ export function initFabMenu(actions = []) {
         }
     });
 
+    console.log("[fabMenu.js] FAB Container pronto para ser adicionado ao body:", container); // Log para diagnóstico
     document.body.appendChild(container);
+    console.log("[fabMenu.js] FAB Container adicionado ao body."); // Log para diagnóstico
 }


### PR DESCRIPTION
- Inclui console.log para verificar a chamada de initFabMenu, o conteúdo de 'actions', e a adição do container FAB ao DOM.
- Remove regra CSS duplicada/conflitante para '.fab-menu-options .cv-button width'.