### PR TITLE
Add floating action menu on main pages

### DIFF
--- a/conViver.Web/js/comunicacao.js
+++ b/conViver.Web/js/comunicacao.js
@@ -1,6 +1,7 @@
 import apiClient from "./apiClient.js";
 import { requireAuth } from "./auth.js";
 import { showGlobalFeedback } from "./main.js";
+import { initFabMenu, setFabMenuActions } from "./fabMenu.js";
 
 // --- Global state & constants ---
 let currentFeedPage = 1;
@@ -182,7 +183,8 @@ document.addEventListener("DOMContentLoaded", async () => {
   await loadInitialFeedItems();
   setupFeedObserver();
   setupFeedContainerClickListener();
-  updateUserSpecificUI(); // Setup FABs
+  initFabMenu();
+  updateUserSpecificUI();
   setupFilterModalAndButton(); // Setup filter modal and its trigger
   setupModalEventListeners(); // Setup generic close/submit for other modals
 });
@@ -709,40 +711,23 @@ function updateUserSpecificUI(activeTabId = "tab-mural") {
   const isSindico =
     userRoles.includes("Sindico") || userRoles.includes("Administrador");
 
-  const fabMural = document.querySelector(".js-fab-mural");
-  const fabEnquetes = document.querySelector(".js-fab-enquetes");
-  const fabSolicitacoes = document.querySelector(".js-fab-chamados");
-
-  if (fabMural) fabMural.style.display = "none";
-  if (fabEnquetes) fabEnquetes.style.display = "none";
-  if (fabSolicitacoes) fabSolicitacoes.style.display = "none";
-
-  if (fabMural && !fabMural.dataset.listenerAttached) {
-    fabMural.addEventListener("click", openCriarAvisoModal);
-    fabMural.dataset.listenerAttached = "true";
-  }
-  if (fabEnquetes && !fabEnquetes.dataset.listenerAttached) {
-    fabEnquetes.addEventListener("click", openCreateEnqueteModal);
-    fabEnquetes.dataset.listenerAttached = "true";
-  }
-  if (fabSolicitacoes && !fabSolicitacoes.dataset.listenerAttached) {
-    fabSolicitacoes.addEventListener("click", openCreateChamadoModal);
-    fabSolicitacoes.dataset.listenerAttached = "true";
-  }
+  const actions = [];
 
   if (activeTabId === "tab-mural") {
     if (isSindico) {
-      if (fabMural) fabMural.style.display = "block";
-    } else {
-      if (fabSolicitacoes) fabSolicitacoes.style.display = "block";
+      actions.push({ label: "Aviso", onClick: openCriarAvisoModal });
+      actions.push({ label: "Enquete", onClick: openCreateEnqueteModal });
     }
+    actions.push({ label: "Solicitação", onClick: openCreateChamadoModal });
   } else if (activeTabId === "tab-enquetes") {
     if (isSindico) {
-      if (fabEnquetes) fabEnquetes.style.display = "block";
+      actions.push({ label: "Enquete", onClick: openCreateEnqueteModal });
     }
   } else if (activeTabId === "tab-solicitacoes" || activeTabId === "tab-ocorrencias") {
-    if (fabSolicitacoes) fabSolicitacoes.style.display = "block";
+    actions.push({ label: "Solicitação", onClick: openCreateChamadoModal });
   }
+
+  setFabMenuActions(actions);
 
   const sindicoOnlyMessages = document.querySelectorAll(
     ".js-sindico-only-message"

--- a/conViver.Web/js/fabMenu.js
+++ b/conViver.Web/js/fabMenu.js
@@ -1,17 +1,42 @@
+let fabMenuContainer = null;
+
 export function initFabMenu(actions = []) {
-    if (!actions || actions.length === 0) return;
+    if (!fabMenuContainer) {
+        fabMenuContainer = document.createElement('div');
+        fabMenuContainer.className = 'fab-menu';
 
-    const container = document.createElement('div');
-    container.className = 'fab-menu';
+        const mainBtn = document.createElement('button');
+        mainBtn.className = 'fab fab-main';
+        mainBtn.type = 'button';
+        mainBtn.textContent = '+';
+        fabMenuContainer.appendChild(mainBtn);
 
-    const mainBtn = document.createElement('button');
-    mainBtn.className = 'fab fab-main';
-    mainBtn.type = 'button';
-    mainBtn.textContent = '+';
-    container.appendChild(mainBtn);
+        const menu = document.createElement('div');
+        menu.className = 'fab-menu-options';
+        fabMenuContainer.appendChild(menu);
 
-    const menu = document.createElement('div');
-    menu.className = 'fab-menu-options';
+        mainBtn.addEventListener('click', () => {
+            fabMenuContainer.classList.toggle('fab-menu--open');
+        });
+
+        document.addEventListener('click', (e) => {
+            if (!fabMenuContainer.contains(e.target)) {
+                fabMenuContainer.classList.remove('fab-menu--open');
+            }
+        });
+
+        document.body.appendChild(fabMenuContainer);
+    }
+
+    setFabMenuActions(actions);
+    return fabMenuContainer;
+}
+
+export function setFabMenuActions(actions = []) {
+    if (!fabMenuContainer) return;
+    const menu = fabMenuContainer.querySelector('.fab-menu-options');
+    if (!menu) return;
+    menu.innerHTML = '';
     actions.forEach(act => {
         const btn = document.createElement('button');
         btn.className = 'cv-button';
@@ -19,24 +44,11 @@ export function initFabMenu(actions = []) {
         if (typeof act.onClick === 'function') {
             btn.addEventListener('click', () => {
                 act.onClick();
-                container.classList.remove('fab-menu--open');
+                fabMenuContainer.classList.remove('fab-menu--open');
             });
         } else if (act.href) {
             btn.addEventListener('click', () => { window.location.href = act.href; });
         }
         menu.appendChild(btn);
     });
-    container.appendChild(menu);
-
-    mainBtn.addEventListener('click', () => {
-        container.classList.toggle('fab-menu--open');
-    });
-
-    document.addEventListener('click', (e) => {
-        if (!container.contains(e.target)) {
-            container.classList.remove('fab-menu--open');
-        }
-    });
-
-    document.body.appendChild(container);
 }

--- a/conViver.Web/js/portaria.js
+++ b/conViver.Web/js/portaria.js
@@ -1,6 +1,7 @@
 import apiClient from './apiClient.js';
 import { requireAuth } from './auth.js';
 import { showGlobalFeedback } from './main.js';
+import { initFabMenu, setFabMenuActions } from './fabMenu.js';
 
 // --- Configuração das Abas Principais ---
 function setupMainTabs() {
@@ -346,6 +347,25 @@ if(btnLimparFiltroHistorico) {
     });
 }
 
+function openRegistrarVisitante() {
+    const btn = document.querySelector('#content-controle-visitantes .cv-tab-button[data-subtab="registrar-visitante"]');
+    btn?.click();
+}
+
+function openRegistrarEncomenda() {
+    const btn = document.querySelector('#content-controle-visitantes .cv-tab-button[data-subtab="gestao-encomendas"]');
+    btn?.click();
+    document.getElementById('formNovaEncomenda')?.scrollIntoView({ behavior: 'smooth' });
+}
+
+function updateFabActions() {
+    const actions = [
+        { label: 'Visitante', onClick: openRegistrarVisitante },
+        { label: 'Encomenda', onClick: openRegistrarEncomenda }
+    ];
+    setFabMenuActions(actions);
+}
+
 // --- DOMContentLoaded ---
 document.addEventListener('DOMContentLoaded', async () => {
     requireAuth();
@@ -354,6 +374,8 @@ document.addEventListener('DOMContentLoaded', async () => {
     adicionarListenersSaida();
     await carregarEncomendas();
     setupEncomendas();
+    initFabMenu();
+    updateFabActions();
 
     // Note: Filter listeners for "Visitantes Atuais" are still placeholders
     const btnFilterAtuais = document.getElementById('btnFiltrarVisitantesAtuais');

--- a/conViver.Web/js/reservas.js
+++ b/conViver.Web/js/reservas.js
@@ -1,6 +1,7 @@
 import { showGlobalFeedback } from "./main.js";
 import { requireAuth, getUserInfo, getRoles } from "./auth.js";
 import apiClient from "./apiClient.js";
+import { initFabMenu } from "./fabMenu.js";
 // FullCalendar is loaded globally via CDN in reservas.html. Here we pull the
 // needed constructors/plugins from the global object to avoid module
 // resolution issues when running without a bundler.
@@ -17,6 +18,7 @@ let currentUserId = null;
 let currentUserRoles = [];
 let agendaDiaListContainer, agendaDiaLoading, agendaDiaSkeleton;
 let dataSelecionadaAgenda = new Date().toISOString().split("T")[0];
+let openNovaReservaModal;
 
 // List View (Agenda Tab)
 let currentPageListView = 1;
@@ -250,11 +252,11 @@ document.addEventListener("DOMContentLoaded", async () => {
 
   // Inicializa tudo
   await initReservasPage();
+  initFabMenu([{ label: "Reserva", onClick: openNovaReservaModal }]);
 });
 
 async function initReservasPage() {
   // Elementos de nova reserva
-  const fabNovaReserva = document.getElementById("fab-nova-reserva");
   const modalNovaReserva = document.getElementById("modal-nova-reserva");
   const closeModalNovaReservaButton = modalNovaReserva?.querySelector(
     ".js-modal-nova-reserva-close"
@@ -303,8 +305,7 @@ async function initReservasPage() {
     "form-gerenciar-espaco-comum"
   );
 
-  // Abre modal de nova reserva
-  fabNovaReserva?.addEventListener("click", () => {
+  openNovaReservaModal = function () {
     document.getElementById("modal-nova-reserva-title").textContent =
       "Solicitar Nova Reserva";
     formNovaReserva.reset();
@@ -317,14 +318,13 @@ async function initReservasPage() {
     document.getElementById("modal-reserva-termos").disabled = false;
     modalNovaReserva.style.display = "flex";
 
-    // Pré-seleciona o espaço
     let esp = "";
     if (calendarioViewContainer.style.display !== "none")
       esp = selectEspacoComumCalendario.value;
     else esp = filtroEspacoLista.value;
     modalSelectEspaco.value = esp;
     exibirInfoEspacoSelecionadoModal(esp);
-  });
+  }
 
   closeModalNovaReservaButton?.addEventListener(
     "click",

--- a/conViver.Web/pages/comunicacao.html
+++ b/conViver.Web/pages/comunicacao.html
@@ -322,10 +322,7 @@
         </div>
     </div>
 
-    <!-- Floating Action Buttons (controlados por JS) -->
-    <button class="fab js-fab-mural" title="Criar Aviso" style="display:none;">+</button>
-    <button class="fab js-fab-enquetes" title="Nova Enquete" style="display:none;">+</button>
-    <button class="fab js-fab-chamados" title="Novo Chamado" style="display:none;">+</button>
+    <!-- Floating Action Button menu is injected via JS -->
 
     <script type="module" src="../js/nav.js"></script>
     <script type="module" src="../js/userMenu.js"></script>

--- a/conViver.Web/pages/reservas.html
+++ b/conViver.Web/pages/reservas.html
@@ -293,7 +293,7 @@
         </section>
     </main>
 
-    <button class="fab" id="fab-nova-reserva" title="Nova Reserva" style="display: none;">+</button>
+    <!-- Floating Action Button menu is injected via JS -->
 
     <div id="modal-filtros-reservas" class="cv-modal" style="display:none;">
         <div class="cv-modal-content">

--- a/conViver.Web/wwwroot/js/comunicacao.js
+++ b/conViver.Web/wwwroot/js/comunicacao.js
@@ -1,6 +1,7 @@
 import apiClient from "./apiClient.js";
 import { requireAuth } from "./auth.js";
 import { showGlobalFeedback } from "./main.js";
+import { initFabMenu, setFabMenuActions } from "./fabMenu.js";
 
 // --- Global state & constants ---
 let currentFeedPage = 1;
@@ -182,7 +183,8 @@ document.addEventListener("DOMContentLoaded", async () => {
   await loadInitialFeedItems();
   setupFeedObserver();
   setupFeedContainerClickListener();
-  updateUserSpecificUI(); // Setup FABs
+  initFabMenu();
+  updateUserSpecificUI();
   setupFilterModalAndButton(); // Setup filter modal and its trigger
   setupModalEventListeners(); // Setup generic close/submit for other modals
 });
@@ -709,40 +711,23 @@ function updateUserSpecificUI(activeTabId = "tab-mural") {
   const isSindico =
     userRoles.includes("Sindico") || userRoles.includes("Administrador");
 
-  const fabMural = document.querySelector(".js-fab-mural");
-  const fabEnquetes = document.querySelector(".js-fab-enquetes");
-  const fabSolicitacoes = document.querySelector(".js-fab-chamados");
-
-  if (fabMural) fabMural.style.display = "none";
-  if (fabEnquetes) fabEnquetes.style.display = "none";
-  if (fabSolicitacoes) fabSolicitacoes.style.display = "none";
-
-  if (fabMural && !fabMural.dataset.listenerAttached) {
-    fabMural.addEventListener("click", openCriarAvisoModal);
-    fabMural.dataset.listenerAttached = "true";
-  }
-  if (fabEnquetes && !fabEnquetes.dataset.listenerAttached) {
-    fabEnquetes.addEventListener("click", openCreateEnqueteModal);
-    fabEnquetes.dataset.listenerAttached = "true";
-  }
-  if (fabSolicitacoes && !fabSolicitacoes.dataset.listenerAttached) {
-    fabSolicitacoes.addEventListener("click", openCreateChamadoModal);
-    fabSolicitacoes.dataset.listenerAttached = "true";
-  }
+  const actions = [];
 
   if (activeTabId === "tab-mural") {
     if (isSindico) {
-      if (fabMural) fabMural.style.display = "block";
-    } else {
-      if (fabSolicitacoes) fabSolicitacoes.style.display = "block";
+      actions.push({ label: "Aviso", onClick: openCriarAvisoModal });
+      actions.push({ label: "Enquete", onClick: openCreateEnqueteModal });
     }
+    actions.push({ label: "Solicitação", onClick: openCreateChamadoModal });
   } else if (activeTabId === "tab-enquetes") {
     if (isSindico) {
-      if (fabEnquetes) fabEnquetes.style.display = "block";
+      actions.push({ label: "Enquete", onClick: openCreateEnqueteModal });
     }
   } else if (activeTabId === "tab-solicitacoes" || activeTabId === "tab-ocorrencias") {
-    if (fabSolicitacoes) fabSolicitacoes.style.display = "block";
+    actions.push({ label: "Solicitação", onClick: openCreateChamadoModal });
   }
+
+  setFabMenuActions(actions);
 
   const sindicoOnlyMessages = document.querySelectorAll(
     ".js-sindico-only-message"

--- a/conViver.Web/wwwroot/js/reservas.js
+++ b/conViver.Web/wwwroot/js/reservas.js
@@ -1,6 +1,7 @@
 import { showGlobalFeedback } from "./main.js";
 import { requireAuth, getUserInfo, getRoles } from "./auth.js";
 import apiClient from "./apiClient.js";
+import { initFabMenu } from "./fabMenu.js";
 import FullCalendar from "@fullcalendar/core";
 import dayGridPlugin from "@fullcalendar/daygrid";
 import timeGridPlugin from "@fullcalendar/timegrid";
@@ -11,6 +12,7 @@ let espacosComunsList = [];
 let calendarioReservas = null;
 let currentUserId = null;
 let currentUserRoles = [];
+let openNovaReservaModal;
 
 // List View (Agenda e Disponibilidade)
 let currentPageListView = 1;
@@ -130,11 +132,11 @@ document.addEventListener("DOMContentLoaded", async () => {
 
   // Inicializa tudo
   await initReservasPage();
+  initFabMenu([{ label: "Reserva", onClick: openNovaReservaModal }]);
 });
 
 async function initReservasPage() {
   // Elementos de nova reserva
-  const fabNovaReserva = document.getElementById("fab-nova-reserva");
   const modalNovaReserva = document.getElementById("modal-nova-reserva");
   const closeModalNovaReservaButton = modalNovaReserva?.querySelector(
     ".js-modal-nova-reserva-close"
@@ -183,8 +185,7 @@ async function initReservasPage() {
     "form-gerenciar-espaco-comum"
   );
 
-  // Abre modal de nova reserva
-  fabNovaReserva?.addEventListener("click", () => {
+  openNovaReservaModal = function () {
     document.getElementById("modal-nova-reserva-title").textContent =
       "Solicitar Nova Reserva";
     formNovaReserva.reset();
@@ -197,14 +198,13 @@ async function initReservasPage() {
     document.getElementById("modal-reserva-termos").disabled = false;
     modalNovaReserva.style.display = "flex";
 
-    // Pré-seleciona o espaço
     let esp = "";
     if (calendarioViewContainer.style.display !== "none")
       esp = selectEspacoComumCalendario.value;
     else esp = filtroEspacoLista.value;
     modalSelectEspaco.value = esp;
     exibirInfoEspacoSelecionadoModal(esp);
-  });
+  };
 
   closeModalNovaReservaButton?.addEventListener(
     "click",

--- a/conViver.Web/wwwroot/pages/comunicacao.html
+++ b/conViver.Web/wwwroot/pages/comunicacao.html
@@ -322,10 +322,7 @@
         </div>
     </div>
 
-    <!-- Floating Action Buttons (controlados por JS) -->
-    <button class="fab js-fab-mural" title="Criar Aviso" style="display:none;">+</button>
-    <button class="fab js-fab-enquetes" title="Nova Enquete" style="display:none;">+</button>
-    <button class="fab js-fab-chamados" title="Novo Chamado" style="display:none;">+</button>
+    <!-- Floating Action Button menu is injected via JS -->
 
     <script type="module" src="../js/nav.js"></script>
     <script type="module" src="../js/userMenu.js"></script>

--- a/conViver.Web/wwwroot/pages/reservas.html
+++ b/conViver.Web/wwwroot/pages/reservas.html
@@ -225,7 +225,7 @@
         </section>
     </main>
 
-    <button class="fab" id="fab-nova-reserva" title="Nova Reserva" style="display: none;">+</button>
+    <!-- Floating Action Button menu is injected via JS -->
 
     <div id="modal-filtros-reservas" class="cv-modal" style="display:none;">
         <div class="cv-modal-content">


### PR DESCRIPTION
## Summary
- implement global FAB menu helper with update support
- switch comunicação to single FAB menu
- add floating action menu triggers for portaria and reservas
- clean generated wwwroot assets

## Testing
- `dotnet test src/conViver.Tests/conViver.Tests.csproj --configuration Release --no-build` *(fails: dotnet not found)*

------
https://chatgpt.com/codex/tasks/task_e_685dbf37a07c8332874357cc59bebabc