### PR TITLE
Add floating action menus for Portaria and Reservas

### DIFF
--- a/conViver.Web/js/portaria.js
+++ b/conViver.Web/js/portaria.js
@@ -1,6 +1,7 @@
 import apiClient from './apiClient.js';
-import { requireAuth } from './auth.js';
+import { requireAuth, getRoles } from './auth.js';
 import { showGlobalFeedback } from './main.js';
+import { initFabMenu } from './fabMenu.js';
 
 // --- Configuração das Abas Principais ---
 function setupMainTabs() {
@@ -104,6 +105,11 @@ function setupVisitantesSubTabs() {
     if (subTabButtons.length > 0) {
         subTabButtons[0].click();
     }
+}
+
+function openSubTab(id) {
+    const btn = document.querySelector(`#content-controle-visitantes .cv-tab-button[data-subtab="${id}"]`);
+    btn?.click();
 }
 
 
@@ -368,6 +374,16 @@ document.addEventListener('DOMContentLoaded', async () => {
             showGlobalFeedback('Funcionalidade de filtro por unidade (atuais) a ser implementada/conectada com API.', 'info');
         });
     }
+
+    const roles = getRoles();
+    const isSindico = roles.includes('Sindico') || roles.includes('Administrador');
+    const actions = [
+        { label: 'Registrar Visitante', onClick: () => openSubTab('registrar-visitante') }
+    ];
+    if (isSindico) {
+        actions.push({ label: 'Registrar Encomenda', onClick: () => openSubTab('gestao-encomendas') });
+    }
+    initFabMenu(actions);
 });
 
 

--- a/conViver.Web/js/reservas.js
+++ b/conViver.Web/js/reservas.js
@@ -1,6 +1,7 @@
 import { showGlobalFeedback } from "./main.js";
 import { requireAuth, getUserInfo, getRoles } from "./auth.js";
 import apiClient from "./apiClient.js";
+import { initFabMenu } from "./fabMenu.js";
 // FullCalendar is loaded globally via CDN in reservas.html. Here we pull the
 // needed constructors/plugins from the global object to avoid module
 // resolution issues when running without a bundler.
@@ -250,6 +251,20 @@ document.addEventListener("DOMContentLoaded", async () => {
 
   // Inicializa tudo
   await initReservasPage();
+
+  const actions = [
+    {
+      label: "Nova Reserva",
+      onClick: () => document.getElementById("fab-nova-reserva")?.click(),
+    },
+  ];
+  if (currentUserRoles.includes("Sindico") || currentUserRoles.includes("Administrador")) {
+    actions.push({
+      label: "Novo Espaço Comum",
+      onClick: () => document.getElementById("btn-adicionar-espaco")?.click(),
+    });
+  }
+  initFabMenu(actions);
 });
 
 async function initReservasPage() {

--- a/conViver.Web/pages/portaria.html
+++ b/conViver.Web/pages/portaria.html
@@ -176,6 +176,7 @@
     </main>
     <script type="module" src="../js/nav.js"></script>
     <script type="module" src="../js/userMenu.js"></script>
+    <script type="module" src="../js/fabMenu.js"></script>
     <script type="module" src="../js/portaria.js"></script>
 </body>
 </html>

--- a/conViver.Web/pages/reservas.html
+++ b/conViver.Web/pages/reservas.html
@@ -510,6 +510,7 @@
     <script type="module" src="../js/nav.js"></script>
     <script type="module" src="../js/userMenu.js"></script>
     <script type="module" src="../js/main.js"></script> <!-- Adicionado main.js para feedback global e tema -->
+    <script type="module" src="../js/fabMenu.js"></script>
     <script src='https://cdn.jsdelivr.net/npm/fullcalendar@6.1.11/main.min.js'></script>
     <script src='https://cdn.jsdelivr.net/npm/fullcalendar@6.1.11/locales/pt-br.js'></script>
     <script type="module" src="../js/reservas.js"></script>


### PR DESCRIPTION
## Summary
- include `fabMenu.js` in Portaria and Reservas pages
- add floating menu actions in `portaria.js` and `reservas.js`

## Testing
- `dotnet test --no-build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685dc49259c88332be75d5fee7dc901a