### PR TITLE
Add skeleton helper utilities

### DIFF
--- a/README.md
+++ b/README.md
@@ -209,6 +209,7 @@ O cliente web (`conViver.Web`) utiliza um sistema de feedback visual global para
 - Um overlay de carregamento (`<div id="global-loading-overlay">`) é exibido durante as requisições.
 - Mensagens de sucesso ou erro são exibidas em um banner (`<div id="global-message-banner">`).
 - Esta funcionalidade é gerenciada automaticamente por `js/apiClient.js`.
+- Para mostrar ou ocultar placeholders de carregamento (skeletons), utilize `showSkeleton()` e `hideSkeleton()` de `js/main.js` nos módulos.
 
 ### Estrutura de Páginas & Navegação
 As páginas HTML da aplicação web ficam em `conViver.Web/pages`. Crie novos arquivos nesse diretório para adicionar funcionalidades.

--- a/conViver.Web/js/comunicacao.js
+++ b/conViver.Web/js/comunicacao.js
@@ -1,6 +1,6 @@
 import apiClient from "./apiClient.js";
 import { requireAuth } from "./auth.js";
-import { showGlobalFeedback } from "./main.js";
+import { showGlobalFeedback, showSkeleton, hideSkeleton } from "./main.js";
 import { initFabMenu } from "./fabMenu.js";
 
 // --- Global state & constants ---
@@ -34,20 +34,13 @@ function showFeedSkeleton(tabContentId = "content-mural") {
     }
   }
 
-  const skeletonContainer = tabContentElement.querySelector(".feed-skeleton-container");
-  if (skeletonContainer) {
-    skeletonContainer.style.display = "block";
-  }
+  showSkeleton(tabContentElement);
 }
 
 function hideFeedSkeleton(tabContentId = "content-mural") {
   const tabContentElement = document.getElementById(tabContentId);
   if (!tabContentElement) return;
-
-  const skeletonContainer = tabContentElement.querySelector(".feed-skeleton-container");
-  if (skeletonContainer) {
-    skeletonContainer.style.display = "none";
-  }
+  hideSkeleton(tabContentElement);
   // Restore info message if no actual content is loaded for certain tabs
   if (tabContentId === "content-enquetes" || tabContentId === "content-solicitacoes") {
     const infoMessage = tabContentElement.querySelector(".cv-info-message");

--- a/conViver.Web/js/main.js
+++ b/conViver.Web/js/main.js
@@ -129,6 +129,54 @@ export function showGlobalFeedback(message, type = 'info', duration) {
     }
 }
 
+/**
+ * Exibe contêineres de skeleton para um seletor ou elemento.
+ * Se o seletor apontar para o próprio contêiner, ele é exibido; caso
+ * contrário, procura por um filho com `.feed-skeleton-container`.
+ * @param {string|Element|NodeList} target CSS selector ou elemento(s)
+ */
+export function showSkeleton(target) {
+    const elements = typeof target === 'string'
+        ? document.querySelectorAll(target)
+        : target instanceof Element
+            ? [target]
+            : target instanceof NodeList || Array.isArray(target)
+                ? target
+                : [];
+    elements.forEach(el => {
+        if (!el) return;
+        if (el.classList && el.classList.contains('feed-skeleton-container')) {
+            el.style.display = 'block';
+        } else {
+            const container = el.querySelector('.feed-skeleton-container');
+            if (container) container.style.display = 'block';
+        }
+    });
+}
+
+/**
+ * Oculta contêineres de skeleton exibidos com `showSkeleton`.
+ * @param {string|Element|NodeList} target CSS selector ou elemento(s)
+ */
+export function hideSkeleton(target) {
+    const elements = typeof target === 'string'
+        ? document.querySelectorAll(target)
+        : target instanceof Element
+            ? [target]
+            : target instanceof NodeList || Array.isArray(target)
+                ? target
+                : [];
+    elements.forEach(el => {
+        if (!el) return;
+        if (el.classList && el.classList.contains('feed-skeleton-container')) {
+            el.style.display = 'none';
+        } else {
+            const container = el.querySelector('.feed-skeleton-container');
+            if (container) container.style.display = 'none';
+        }
+    });
+}
+
 
 // Exemplo de como poderia ser usado para inicializações (se necessário no futuro):
 // document.addEventListener('DOMContentLoaded', () => {

--- a/conViver.Web/js/reservas.js
+++ b/conViver.Web/js/reservas.js
@@ -1,4 +1,4 @@
-import { showGlobalFeedback } from "./main.js";
+import { showGlobalFeedback, showSkeleton, hideSkeleton } from "./main.js";
 import { requireAuth, getUserInfo, getRoles } from "./auth.js";
 import apiClient from "./apiClient.js";
 import { initFabMenu } from "./fabMenu.js";
@@ -1203,7 +1203,7 @@ function initializeFullCalendar() {
 async function carregarReservasDia(dataStr) {
   if (!agendaDiaListContainer) return;
   agendaDiaListContainer.innerHTML = "";
-  if (agendaDiaSkeleton) agendaDiaSkeleton.style.display = "block";
+  showSkeleton(agendaDiaSkeleton);
   if (agendaDiaLoading) agendaDiaLoading.style.display = "block";
   try {
     const params = {
@@ -1224,7 +1224,7 @@ async function carregarReservasDia(dataStr) {
     console.error("Erro ao carregar reservas do dia:", err);
     agendaDiaListContainer.innerHTML = '<p class="cv-error-message" style="text-align:center;">Erro ao carregar reservas.</p>';
   } finally {
-    if (agendaDiaSkeleton) agendaDiaSkeleton.style.display = "none";
+    hideSkeleton(agendaDiaSkeleton);
     if (agendaDiaLoading) agendaDiaLoading.style.display = "none";
   }
 }


### PR DESCRIPTION
## Summary
- add `showSkeleton` and `hideSkeleton` utilities
- use skeleton helpers in comunicação and reservas modules
- mention skeleton helpers in README

## Testing
- `dotnet format --no-restore`
- `dotnet test conViver.Tests/conViver.Tests.csproj --no-restore` *(fails: Program is inaccessible)*

------
https://chatgpt.com/codex/tasks/task_e_685dd02187e88332bec39047a75d74bc