### PR TITLE
Add skeleton loaders to source templates

### DIFF
--- a/conViver.Web/js/biblioteca.js
+++ b/conViver.Web/js/biblioteca.js
@@ -1,6 +1,7 @@
 import apiClient from './apiClient.js';
 import { requireAuth, getUserRoles } from './auth.js'; // Supondo que getUserRoles exista ou será criado
 import { showGlobalFeedback } from './main.js';
+import { showFeedSkeleton, hideFeedSkeleton } from './skeleton.js';
 
 document.addEventListener('DOMContentLoaded', async () => {
     requireAuth();
@@ -44,7 +45,9 @@ function initializeBibliotecaPage() {
 async function loadDocumentos() {
     const listContainer = document.querySelector('.js-document-list');
     if (!listContainer) return;
+    const skeleton = document.getElementById('biblioteca-skeleton');
 
+    if (skeleton) showFeedSkeleton(skeleton);
     listContainer.innerHTML = '<p class="cv-loading-message">Carregando documentos...</p>';
 
     const searchTerm = document.getElementById('docSearchInput')?.value || '';
@@ -82,10 +85,10 @@ async function loadDocumentos() {
         console.error('Erro ao carregar documentos:', error);
         listContainer.innerHTML = '<p class="cv-error-message">Erro ao carregar documentos. Tente novamente mais tarde.</p>';
         showGlobalFeedback('Erro ao carregar documentos.', 'error');
+    } finally {
+        if (skeleton) hideFeedSkeleton(skeleton);
     }
 }
-
-function renderDocumentos(documentos, container) {
     container.innerHTML = ''; // Limpa a lista
     const userRoles = getUserRoles();
     const isSindico = userRoles.includes('Sindico') || userRoles.includes('Administrador');

--- a/conViver.Web/js/dashboard.js
+++ b/conViver.Web/js/dashboard.js
@@ -2,6 +2,7 @@ import apiClient, { ApiError } from './apiClient.js';
 import { requireAuth, getUserRoles } from './auth.js';
 import { formatCurrency, formatDate, showGlobalFeedback } from './main.js'; // Updated import
 import { initFabMenu } from './fabMenu.js';
+import { showFeedSkeleton, hideFeedSkeleton } from './skeleton.js';
 
 document.addEventListener('DOMContentLoaded', async () => {
     requireAuth(); // Ensures user is authenticated before proceeding
@@ -17,6 +18,7 @@ document.addEventListener('DOMContentLoaded', async () => {
     const inadimplenciaChartCanvas = document.getElementById('inadimplenciaChart');
     let inadimplenciaChartInstance = null; // Para manter a instância do gráfico
 
+    const dashboardSkeleton = document.getElementById('dashboard-skeleton');
     // Loading indicator (simple text for now, could be a spinner) - Kept for local loading messages if still desired
     const showLoading = (container, message = "Carregando...") => {
         if (container) container.innerHTML = `<p class="loading-message">${message}</p>`;
@@ -220,6 +222,7 @@ document.addEventListener('DOMContentLoaded', async () => {
     }
 
     async function carregarDadosDashboard() {
+        if (dashboardSkeleton) showFeedSkeleton(dashboardSkeleton);
         showGlobalFeedback('Carregando dados do dashboard...', 'info', 3000);
 
         // Set loading states for all sections (local indicators can remain or be removed if global is sufficient)
@@ -267,6 +270,8 @@ document.addEventListener('DOMContentLoaded', async () => {
                 errorMessage = error.message;
             }
             showGlobalFeedback(errorMessage, 'error');
+        } finally {
+            if (dashboardSkeleton) hideFeedSkeleton(dashboardSkeleton);
         }
     }
 

--- a/conViver.Web/js/financeiro.js
+++ b/conViver.Web/js/financeiro.js
@@ -1,6 +1,7 @@
 import apiClient, { ApiError } from './apiClient.js';
 import { requireAuth } from './auth.js';
 import { formatCurrency, formatDate, showGlobalFeedback } from './main.js'; // Updated import
+import { showFeedSkeleton, hideFeedSkeleton } from './skeleton.js';
 
 document.addEventListener('DOMContentLoaded', () => {
     requireAuth();
@@ -13,6 +14,7 @@ document.addEventListener('DOMContentLoaded', () => {
     const summaryPixEl = document.querySelector('.js-summary-pix');
     const summaryPendentesEl = document.querySelector('.js-summary-pendentes');
 
+    const cobrancasSkeleton = document.getElementById('financeiro-skeleton');
     // Modal elements
     const modalCobranca = document.getElementById('modalCobranca');
     const modalCobrancaTitle = document.getElementById('modalCobrancaTitle');
@@ -300,6 +302,7 @@ document.addEventListener('DOMContentLoaded', () => {
     async function fetchAndRenderCobrancas(status = '') {
         if (!tbodyCobrancas) return;
         tbodyCobrancas.innerHTML = '<tr><td colspan="6" class="text-center">Carregando cobranças...</td></tr>';
+        if (cobrancasSkeleton) showFeedSkeleton(cobrancasSkeleton);
 
         let apiUrl = '/financeiro/cobrancas';
         if (status) {
@@ -318,10 +321,13 @@ document.addEventListener('DOMContentLoaded', () => {
             } else {
                 showGlobalFeedback(defaultMessage, 'error');
             }
+        } finally {
+            if (cobrancasSkeleton) hideFeedSkeleton(cobrancasSkeleton);
         }
     }
 
     async function fetchAndRenderDashboard() {
+        if (cobrancasSkeleton) showFeedSkeleton(cobrancasSkeleton);
         if (summaryInadimplenciaEl) summaryInadimplenciaEl.textContent = 'Carregando...';
         if (summaryPixEl) summaryPixEl.textContent = 'Carregando...';
         if (summaryPendentesEl) summaryPendentesEl.textContent = 'Carregando...';
@@ -338,6 +344,8 @@ document.addEventListener('DOMContentLoaded', () => {
             } else {
                 showGlobalFeedback(defaultMessage, 'error');
             }
+        } finally {
+            if (cobrancasSkeleton) hideFeedSkeleton(cobrancasSkeleton);
         }
     }
 

--- a/conViver.Web/js/portaria.js
+++ b/conViver.Web/js/portaria.js
@@ -2,6 +2,7 @@ import apiClient from './apiClient.js';
 import { requireAuth, getRoles } from './auth.js';
 import { showGlobalFeedback } from './main.js';
 import { initFabMenu } from './fabMenu.js';
+import { showFeedSkeleton, hideFeedSkeleton } from './skeleton.js';
 
 // --- Configuração das Abas Principais ---
 function setupMainTabs() {
@@ -117,6 +118,7 @@ async function carregarVisitantesAtuais(unidadeFilter = '') {
     const tbody = document.querySelector('.js-visitantes-atuais-lista');
     const loadingMsg = document.getElementById('visitantesAtuaisLoadingMsg');
     const noDataMsg = document.getElementById('visitantesAtuaisNoDataMsg');
+    const skeleton = document.getElementById('visitantes-skeleton');
 
     if (!tbody || !loadingMsg || !noDataMsg) {
         console.error('Elementos da tabela de visitantes atuais não encontrados.');
@@ -126,6 +128,7 @@ async function carregarVisitantesAtuais(unidadeFilter = '') {
 
     tbody.innerHTML = '';
     loadingMsg.style.display = 'block';
+    if (skeleton) showFeedSkeleton(skeleton);
     noDataMsg.style.display = 'none';
     // Do not show global feedback for loading here, it's too noisy for tab switches / auto-refresh
     // showGlobalFeedback('Carregando visitantes atuais...', 'info');
@@ -166,6 +169,8 @@ async function carregarVisitantesAtuais(unidadeFilter = '') {
         loadingMsg.style.display = 'none';
         tbody.innerHTML = '<tr><td colspan="7" class="error-message">Falha ao carregar visitantes atuais.</td></tr>';
         showGlobalFeedback('Erro ao carregar visitantes atuais: ' + (err.message || 'Erro desconhecido'), 'error');
+    } finally {
+        if (skeleton) hideFeedSkeleton(skeleton);
     }
 }
 
@@ -283,8 +288,11 @@ async function carregarHistoricoVisitantes(filters = {}) {
         return;
     }
 
+    const skeleton = document.getElementById('historico-skeleton');
+
     historicoTbody.innerHTML = '';
     historicoLoadingMsg.style.display = 'block';
+    if (skeleton) showFeedSkeleton(skeleton);
     historicoNoDataMsg.style.display = 'none';
     showGlobalFeedback('Carregando histórico de visitantes...', 'info');
 
@@ -324,6 +332,8 @@ async function carregarHistoricoVisitantes(filters = {}) {
         historicoLoadingMsg.style.display = 'none';
         historicoTbody.innerHTML = '<tr><td colspan="8" class="error-message">Falha ao carregar histórico.</td></tr>';
         showGlobalFeedback('Erro ao carregar histórico: ' + (err.message || 'Erro desconhecido'), 'error');
+    } finally {
+        if (skeleton) hideFeedSkeleton(skeleton);
     }
 }
 
@@ -398,6 +408,7 @@ async function carregarEncomendas() {
     const tbody = document.querySelector('.js-encomendas');
     const loadingMsg = document.getElementById('encomendasLoadingMsg');
     const noDataMsg = document.getElementById('encomendasNoDataMsg');
+    const skeleton = document.getElementById('encomendas-skeleton');
     if (!tbody || !loadingMsg || !noDataMsg) {
         console.error('Elementos de encomendas não encontrados.');
         return;
@@ -405,6 +416,7 @@ async function carregarEncomendas() {
     tbody.innerHTML = '';
     loadingMsg.style.display = 'block';
     noDataMsg.style.display = 'none';
+    if (skeleton) showFeedSkeleton(skeleton);
 
     try {
         const encomendas = await apiClient.get('/syndic/encomendas?status=recebida');
@@ -425,6 +437,8 @@ async function carregarEncomendas() {
     } catch(err) {
         console.error('Erro ao listar encomendas', err);
         tbody.innerHTML = '<tr><td colspan="4" class="error-message">Falha ao carregar encomendas.</td></tr>';
+    } finally {
+        if (skeleton) hideFeedSkeleton(skeleton);
     }
 }
 

--- a/conViver.Web/js/skeleton.js
+++ b/conViver.Web/js/skeleton.js
@@ -1,0 +1,9 @@
+export function showFeedSkeleton(selector = '.feed-skeleton-container') {
+  const el = typeof selector === 'string' ? document.querySelector(selector) : selector;
+  if (el) el.style.display = 'block';
+}
+
+export function hideFeedSkeleton(selector = '.feed-skeleton-container') {
+  const el = typeof selector === 'string' ? document.querySelector(selector) : selector;
+  if (el) el.style.display = 'none';
+}

--- a/conViver.Web/pages/biblioteca.html
+++ b/conViver.Web/pages/biblioteca.html
@@ -47,6 +47,10 @@
         <section class="cv-section">
             <div class="document-list js-document-list">
                 <!-- Documentos serão carregados aqui por JS -->
+                <div id="biblioteca-skeleton" class="feed-skeleton-container" style="display:none;">
+                    <div class="cv-card feed-skeleton-item"><div class="skeleton-title"></div><div class="skeleton-line"></div><div class="skeleton-line short"></div></div>
+                    <div class="cv-card feed-skeleton-item"><div class="skeleton-title"></div><div class="skeleton-line"></div><div class="skeleton-line short"></div></div>
+                </div>
                 <p class="cv-loading-message">Carregando documentos...</p>
             </div>
         </section>

--- a/conViver.Web/pages/dashboard.html
+++ b/conViver.Web/pages/dashboard.html
@@ -27,6 +27,10 @@
     </div>
     <nav id="mainNav"></nav>
     <main class="cv-container db-main">
+        <div id="dashboard-skeleton" class="feed-skeleton-container" style="display:none;">
+            <div class="cv-card feed-skeleton-item"><div class="skeleton-title"></div><div class="skeleton-line"></div><div class="skeleton-line short"></div></div>
+            <div class="cv-card feed-skeleton-item"><div class="skeleton-title"></div><div class="skeleton-line"></div><div class="skeleton-line short"></div></div>
+        </div>
         <section class="db-section db-section--metrics">
             <h2 class="db-section__title">Visão Geral</h2>
             <div class="db-metrics-grid">

--- a/conViver.Web/pages/financeiro.html
+++ b/conViver.Web/pages/financeiro.html
@@ -66,6 +66,10 @@
 
         <section class="db-section fin-cobrancas__table-section">
             <h2 class="db-section__title">Lista de Cobranças</h2>
+            <div id="financeiro-skeleton" class="feed-skeleton-container" style="display:none;">
+                <div class="cv-card feed-skeleton-item"><div class="skeleton-title"></div><div class="skeleton-line"></div><div class="skeleton-line short"></div></div>
+                <div class="cv-card feed-skeleton-item"><div class="skeleton-title"></div><div class="skeleton-line"></div><div class="skeleton-line short"></div></div>
+            </div>
             <div class="table-responsive">
                 <table class="cv-table fin-cobrancas__table">
                     <thead>

--- a/conViver.Web/pages/perfil.html
+++ b/conViver.Web/pages/perfil.html
@@ -27,6 +27,10 @@
     <nav id="mainNav"></nav>
     <main class="cv-container perfil-main">
         <h1 class="perfil-title">Configurações do Perfil</h1>
+        <div id="perfil-skeleton" class="feed-skeleton-container" style="display:none;">
+            <div class="cv-card feed-skeleton-item"><div class="skeleton-title"></div><div class="skeleton-line"></div><div class="skeleton-line short"></div></div>
+            <div class="cv-card feed-skeleton-item"><div class="skeleton-title"></div><div class="skeleton-line"></div><div class="skeleton-line short"></div></div>
+        </div>
         <form class="perfil-form">
             <div class="perfil-form-group">
                 <label for="profilePhoto">Foto:</label>

--- a/conViver.Web/pages/portaria.html
+++ b/conViver.Web/pages/portaria.html
@@ -12,6 +12,10 @@
 
                 <div id="visitantes-atuais" class="cv-subtab-content active">
                     <h3>Visitantes Atuais no Condomínio</h3>
+                    <div id="visitantes-skeleton" class="feed-skeleton-container" style="display:none;">
+                        <div class="cv-card feed-skeleton-item"><div class="skeleton-title"></div><div class="skeleton-line"></div><div class="skeleton-line short"></div></div>
+                        <div class="cv-card feed-skeleton-item"><div class="skeleton-title"></div><div class="skeleton-line"></div><div class="skeleton-line short"></div></div>
+                    </div>
                     <div class="filters">
                         <input type="text" id="filterUnidadeVisitantesAtuais" placeholder="Filtrar por Unidade (Ex: A101)">
                         <button id="btnFiltrarVisitantesAtuais" class="cv-button cv-button--small">Filtrar</button>
@@ -79,6 +83,10 @@
 
                 <div id="historico-visitantes" class="cv-subtab-content">
                     <h3>Histórico de Visitantes</h3>
+                    <div id="historico-skeleton" class="feed-skeleton-container" style="display:none;">
+                        <div class="cv-card feed-skeleton-item"><div class="skeleton-title"></div><div class="skeleton-line"></div><div class="skeleton-line short"></div></div>
+                        <div class="cv-card feed-skeleton-item"><div class="skeleton-title"></div><div class="skeleton-line"></div><div class="skeleton-line short"></div></div>
+                    </div>
                     <div class="filters">
                         <input type="text" id="filterHistUnidadeId" placeholder="ID da Unidade">
                         <input type="date" id="filterHistDataInicio">
@@ -113,6 +121,10 @@
                 <!-- O h2 foi removido daqui -->
                 <!-- Adicionar sub-abas para Encomendas aqui, se necessário no futuro -->
                 <!-- Por enquanto, o conteúdo existente de encomendas permanece aqui -->
+                <div id="encomendas-skeleton" class="feed-skeleton-container" style="display:none;">
+                    <div class="cv-card feed-skeleton-item"><div class="skeleton-title"></div><div class="skeleton-line"></div><div class="skeleton-line short"></div></div>
+                    <div class="cv-card feed-skeleton-item"><div class="skeleton-title"></div><div class="skeleton-line"></div><div class="skeleton-line short"></div></div>
+                </div>
                 <form id="formNovaEncomenda" class="cv-form">
                     <div class="cv-form-group">
                         <label for="encUnidadeId">Unidade Destino (ID):</label>

--- a/conViver.Web/wwwroot/js/biblioteca.js
+++ b/conViver.Web/wwwroot/js/biblioteca.js
@@ -1,6 +1,7 @@
 import apiClient from './apiClient.js';
 import { requireAuth, getUserRoles } from './auth.js'; // Supondo que getUserRoles exista ou será criado
 import { showGlobalFeedback } from './main.js';
+import { showFeedSkeleton, hideFeedSkeleton } from './skeleton.js';
 
 document.addEventListener('DOMContentLoaded', async () => {
     requireAuth();
@@ -45,7 +46,9 @@ async function loadDocumentos() {
     const listContainer = document.querySelector('.js-document-list');
     if (!listContainer) return;
 
+    const skeleton = document.getElementById('biblioteca-skeleton');
     listContainer.innerHTML = '<p class="cv-loading-message">Carregando documentos...</p>';
+    if (skeleton) showFeedSkeleton(skeleton);
 
     const searchTerm = document.getElementById('docSearchInput')?.value || '';
     const category = document.getElementById('docCategoryFilter')?.value || '';
@@ -82,6 +85,8 @@ async function loadDocumentos() {
         console.error('Erro ao carregar documentos:', error);
         listContainer.innerHTML = '<p class="cv-error-message">Erro ao carregar documentos. Tente novamente mais tarde.</p>';
         showGlobalFeedback('Erro ao carregar documentos.', 'error');
+    } finally {
+        if (skeleton) hideFeedSkeleton(skeleton);
     }
 }
 

--- a/conViver.Web/wwwroot/js/dashboard.js
+++ b/conViver.Web/wwwroot/js/dashboard.js
@@ -2,6 +2,7 @@ import apiClient, { ApiError } from './apiClient.js';
 import { requireAuth, getUserRoles } from './auth.js';
 import { formatCurrency, formatDate, showGlobalFeedback } from './main.js'; // Updated import
 import { initFabMenu } from './fabMenu.js';
+import { showFeedSkeleton, hideFeedSkeleton } from './skeleton.js';
 
 document.addEventListener('DOMContentLoaded', async () => {
     requireAuth(); // Ensures user is authenticated before proceeding
@@ -16,6 +17,7 @@ document.addEventListener('DOMContentLoaded', async () => {
     const ultimosAvisosEl = document.querySelector('.js-db-ultimos-avisos');
     const inadimplenciaChartCanvas = document.getElementById('inadimplenciaChart');
     let inadimplenciaChartInstance = null; // Para manter a instância do gráfico
+    const dashboardSkeleton = document.getElementById('dashboard-skeleton');
 
     // Loading indicator (simple text for now, could be a spinner) - Kept for local loading messages if still desired
     const showLoading = (container, message = "Carregando...") => {
@@ -220,6 +222,7 @@ document.addEventListener('DOMContentLoaded', async () => {
     }
 
     async function carregarDadosDashboard() {
+        if (dashboardSkeleton) showFeedSkeleton(dashboardSkeleton);
         showGlobalFeedback('Carregando dados do dashboard...', 'info', 3000);
 
         // Set loading states for all sections (local indicators can remain or be removed if global is sufficient)
@@ -267,6 +270,8 @@ document.addEventListener('DOMContentLoaded', async () => {
                 errorMessage = error.message;
             }
             showGlobalFeedback(errorMessage, 'error');
+        } finally {
+            if (dashboardSkeleton) hideFeedSkeleton(dashboardSkeleton);
         }
     }
 

--- a/conViver.Web/wwwroot/js/financeiro.js
+++ b/conViver.Web/wwwroot/js/financeiro.js
@@ -1,6 +1,7 @@
 import apiClient, { ApiError } from './apiClient.js';
 import { requireAuth } from './auth.js';
 import { formatCurrency, formatDate, showGlobalFeedback } from './main.js'; // Updated import
+import { showFeedSkeleton, hideFeedSkeleton } from './skeleton.js';
 
 document.addEventListener('DOMContentLoaded', () => {
     requireAuth();
@@ -12,6 +13,7 @@ document.addEventListener('DOMContentLoaded', () => {
     const summaryInadimplenciaEl = document.querySelector('.js-summary-inadimplencia');
     const summaryPixEl = document.querySelector('.js-summary-pix');
     const summaryPendentesEl = document.querySelector('.js-summary-pendentes');
+    const cobrancasSkeleton = document.getElementById('financeiro-skeleton');
 
     // Modal elements
     const modalCobranca = document.getElementById('modalCobranca');
@@ -300,6 +302,7 @@ document.addEventListener('DOMContentLoaded', () => {
     async function fetchAndRenderCobrancas(status = '') {
         if (!tbodyCobrancas) return;
         tbodyCobrancas.innerHTML = '<tr><td colspan="6" class="text-center">Carregando cobranças...</td></tr>';
+        if (cobrancasSkeleton) showFeedSkeleton(cobrancasSkeleton);
 
         let apiUrl = '/financeiro/cobrancas';
         if (status) {
@@ -318,10 +321,13 @@ document.addEventListener('DOMContentLoaded', () => {
             } else {
                 showGlobalFeedback(defaultMessage, 'error');
             }
+        } finally {
+            if (cobrancasSkeleton) hideFeedSkeleton(cobrancasSkeleton);
         }
     }
 
     async function fetchAndRenderDashboard() {
+        if (cobrancasSkeleton) showFeedSkeleton(cobrancasSkeleton);
         if (summaryInadimplenciaEl) summaryInadimplenciaEl.textContent = 'Carregando...';
         if (summaryPixEl) summaryPixEl.textContent = 'Carregando...';
         if (summaryPendentesEl) summaryPendentesEl.textContent = 'Carregando...';
@@ -338,6 +344,8 @@ document.addEventListener('DOMContentLoaded', () => {
             } else {
                 showGlobalFeedback(defaultMessage, 'error');
             }
+        } finally {
+            if (cobrancasSkeleton) hideFeedSkeleton(cobrancasSkeleton);
         }
     }
 

--- a/conViver.Web/wwwroot/js/portaria.js
+++ b/conViver.Web/wwwroot/js/portaria.js
@@ -2,6 +2,7 @@ import apiClient from './apiClient.js';
 import { requireAuth, getRoles } from './auth.js';
 import { showGlobalFeedback } from './main.js';
 import { initFabMenu } from './fabMenu.js';
+import { showFeedSkeleton, hideFeedSkeleton } from './skeleton.js';
 
 // --- Configuração das Abas Principais ---
 function setupMainTabs() {
@@ -117,6 +118,7 @@ async function carregarVisitantesAtuais(unidadeFilter = '') {
     const tbody = document.querySelector('.js-visitantes-atuais-lista');
     const loadingMsg = document.getElementById('visitantesAtuaisLoadingMsg');
     const noDataMsg = document.getElementById('visitantesAtuaisNoDataMsg');
+    const skeleton = document.getElementById('visitantes-skeleton');
 
     if (!tbody || !loadingMsg || !noDataMsg) {
         console.error('Elementos da tabela de visitantes atuais não encontrados.');
@@ -126,6 +128,7 @@ async function carregarVisitantesAtuais(unidadeFilter = '') {
 
     tbody.innerHTML = '';
     loadingMsg.style.display = 'block';
+    if (skeleton) showFeedSkeleton(skeleton);
     noDataMsg.style.display = 'none';
     // Do not show global feedback for loading here, it's too noisy for tab switches / auto-refresh
     // showGlobalFeedback('Carregando visitantes atuais...', 'info');
@@ -166,6 +169,8 @@ async function carregarVisitantesAtuais(unidadeFilter = '') {
         loadingMsg.style.display = 'none';
         tbody.innerHTML = '<tr><td colspan="7" class="error-message">Falha ao carregar visitantes atuais.</td></tr>';
         showGlobalFeedback('Erro ao carregar visitantes atuais: ' + (err.message || 'Erro desconhecido'), 'error');
+    } finally {
+        if (skeleton) hideFeedSkeleton(skeleton);
     }
 }
 
@@ -283,8 +288,11 @@ async function carregarHistoricoVisitantes(filters = {}) {
         return;
     }
 
+    const skeleton = document.getElementById('historico-skeleton');
+
     historicoTbody.innerHTML = '';
     historicoLoadingMsg.style.display = 'block';
+    if (skeleton) showFeedSkeleton(skeleton);
     historicoNoDataMsg.style.display = 'none';
     showGlobalFeedback('Carregando histórico de visitantes...', 'info');
 
@@ -324,6 +332,8 @@ async function carregarHistoricoVisitantes(filters = {}) {
         historicoLoadingMsg.style.display = 'none';
         historicoTbody.innerHTML = '<tr><td colspan="8" class="error-message">Falha ao carregar histórico.</td></tr>';
         showGlobalFeedback('Erro ao carregar histórico: ' + (err.message || 'Erro desconhecido'), 'error');
+    } finally {
+        if (skeleton) hideFeedSkeleton(skeleton);
     }
 }
 
@@ -392,6 +402,7 @@ async function carregarEncomendas() {
     const tbody = document.querySelector('.js-encomendas');
     const loadingMsg = document.getElementById('encomendasLoadingMsg');
     const noDataMsg = document.getElementById('encomendasNoDataMsg');
+    const skeleton = document.getElementById('encomendas-skeleton');
     if (!tbody || !loadingMsg || !noDataMsg) {
         console.error('Elementos de encomendas não encontrados.');
         return;
@@ -399,6 +410,7 @@ async function carregarEncomendas() {
     tbody.innerHTML = '';
     loadingMsg.style.display = 'block';
     noDataMsg.style.display = 'none';
+    if (skeleton) showFeedSkeleton(skeleton);
 
     try {
         const encomendas = await apiClient.get('/syndic/encomendas?status=recebida');
@@ -419,6 +431,8 @@ async function carregarEncomendas() {
     } catch(err) {
         console.error('Erro ao listar encomendas', err);
         tbody.innerHTML = '<tr><td colspan="4" class="error-message">Falha ao carregar encomendas.</td></tr>';
+    } finally {
+        if (skeleton) hideFeedSkeleton(skeleton);
     }
 }
 

--- a/conViver.Web/wwwroot/js/skeleton.js
+++ b/conViver.Web/wwwroot/js/skeleton.js
@@ -1,0 +1,9 @@
+export function showFeedSkeleton(selector = '.feed-skeleton-container') {
+  const el = typeof selector === 'string' ? document.querySelector(selector) : selector;
+  if (el) el.style.display = 'block';
+}
+
+export function hideFeedSkeleton(selector = '.feed-skeleton-container') {
+  const el = typeof selector === 'string' ? document.querySelector(selector) : selector;
+  if (el) el.style.display = 'none';
+}

--- a/conViver.Web/wwwroot/pages/biblioteca.html
+++ b/conViver.Web/wwwroot/pages/biblioteca.html
@@ -46,6 +46,10 @@
         <!-- Lista de Documentos -->
         <section class="cv-section">
             <div class="document-list js-document-list">
+                <div id="biblioteca-skeleton" class="feed-skeleton-container" style="display:none;">
+                    <div class="cv-card feed-skeleton-item"><div class="skeleton-title"></div><div class="skeleton-line"></div><div class="skeleton-line short"></div></div>
+                    <div class="cv-card feed-skeleton-item"><div class="skeleton-title"></div><div class="skeleton-line"></div><div class="skeleton-line short"></div></div>
+                </div>
                 <!-- Documentos serão carregados aqui por JS -->
                 <p class="cv-loading-message">Carregando documentos...</p>
             </div>

--- a/conViver.Web/wwwroot/pages/dashboard.html
+++ b/conViver.Web/wwwroot/pages/dashboard.html
@@ -27,6 +27,10 @@
     </div>
     <nav id="mainNav"></nav>
     <main class="cv-container db-main">
+        <div id="dashboard-skeleton" class="feed-skeleton-container" style="display:none;">
+            <div class="cv-card feed-skeleton-item"><div class="skeleton-title"></div><div class="skeleton-line"></div><div class="skeleton-line short"></div></div>
+            <div class="cv-card feed-skeleton-item"><div class="skeleton-title"></div><div class="skeleton-line"></div><div class="skeleton-line short"></div></div>
+        </div>
         <section class="db-section db-section--metrics">
             <h2 class="db-section__title">Visão Geral</h2>
             <div class="db-metrics-grid">

--- a/conViver.Web/wwwroot/pages/financeiro.html
+++ b/conViver.Web/wwwroot/pages/financeiro.html
@@ -66,6 +66,10 @@
 
         <section class="db-section fin-cobrancas__table-section">
             <h2 class="db-section__title">Lista de Cobranças</h2>
+            <div id="financeiro-skeleton" class="feed-skeleton-container" style="display:none;">
+                <div class="cv-card feed-skeleton-item"><div class="skeleton-title"></div><div class="skeleton-line"></div><div class="skeleton-line short"></div></div>
+                <div class="cv-card feed-skeleton-item"><div class="skeleton-title"></div><div class="skeleton-line"></div><div class="skeleton-line short"></div></div>
+            </div>
             <div class="table-responsive">
                 <table class="cv-table fin-cobrancas__table">
                     <thead>

--- a/conViver.Web/wwwroot/pages/perfil.html
+++ b/conViver.Web/wwwroot/pages/perfil.html
@@ -27,6 +27,10 @@
     <nav id="mainNav"></nav>
     <main class="cv-container perfil-main">
         <h1 class="perfil-title">Configurações do Perfil</h1>
+        <div id="perfil-skeleton" class="feed-skeleton-container" style="display:none;">
+            <div class="cv-card feed-skeleton-item"><div class="skeleton-title"></div><div class="skeleton-line"></div><div class="skeleton-line short"></div></div>
+            <div class="cv-card feed-skeleton-item"><div class="skeleton-title"></div><div class="skeleton-line"></div><div class="skeleton-line short"></div></div>
+        </div>
         <form class="perfil-form">
             <div class="perfil-form-group">
                 <label for="profilePhoto">Foto:</label>

--- a/conViver.Web/wwwroot/pages/portaria.html
+++ b/conViver.Web/wwwroot/pages/portaria.html
@@ -39,6 +39,10 @@
 
                 <div id="visitantes-atuais" class="cv-subtab-content active">
                     <h3>Visitantes Atuais no Condomínio</h3>
+                    <div id="visitantes-skeleton" class="feed-skeleton-container" style="display:none;">
+                        <div class="cv-card feed-skeleton-item"><div class="skeleton-title"></div><div class="skeleton-line"></div><div class="skeleton-line short"></div></div>
+                        <div class="cv-card feed-skeleton-item"><div class="skeleton-title"></div><div class="skeleton-line"></div><div class="skeleton-line short"></div></div>
+                    </div>
                     <div class="filters">
                         <input type="text" id="filterUnidadeVisitantesAtuais" placeholder="Filtrar por Unidade (Ex: A101)">
                         <button id="btnFiltrarVisitantesAtuais" class="cv-button cv-button--small">Filtrar</button>
@@ -106,6 +110,10 @@
 
                 <div id="historico-visitantes" class="cv-subtab-content">
                     <h3>Histórico de Visitantes</h3>
+                    <div id="historico-skeleton" class="feed-skeleton-container" style="display:none;">
+                        <div class="cv-card feed-skeleton-item"><div class="skeleton-title"></div><div class="skeleton-line"></div><div class="skeleton-line short"></div></div>
+                        <div class="cv-card feed-skeleton-item"><div class="skeleton-title"></div><div class="skeleton-line"></div><div class="skeleton-line short"></div></div>
+                    </div>
                     <div class="filters">
                         <input type="text" id="filterHistUnidadeId" placeholder="ID da Unidade">
                         <input type="date" id="filterHistDataInicio">
@@ -140,6 +148,10 @@
                 <!-- O h2 foi removido daqui -->
                 <!-- Adicionar sub-abas para Encomendas aqui, se necessário no futuro -->
                 <!-- Por enquanto, o conteúdo existente de encomendas permanece aqui -->
+                <div id="encomendas-skeleton" class="feed-skeleton-container" style="display:none;">
+                    <div class="cv-card feed-skeleton-item"><div class="skeleton-title"></div><div class="skeleton-line"></div><div class="skeleton-line short"></div></div>
+                    <div class="cv-card feed-skeleton-item"><div class="skeleton-title"></div><div class="skeleton-line"></div><div class="skeleton-line short"></div></div>
+                </div>
                 <form id="formNovaEncomenda" class="cv-form">
                     <div class="cv-form-group">
                         <label for="encUnidadeId">Unidade Destino (ID):</label>


### PR DESCRIPTION
## Summary
- create `skeleton.js` utility in source scripts
- toggle skeleton containers in `biblioteca`, `dashboard`, `financeiro` and `portaria` JS modules
- embed skeleton markup into HTML pages under `conViver.Web/pages`

## Testing
- `dotnet test conViver.Tests/conViver.Tests.csproj --configuration Release --no-build` *(fails: dotnet not found)*

------
https://chatgpt.com/codex/tasks/task_e_685dd1bf9108833289cbc59aa4ae24e1