### PR TITLE
Implement cv-alert--hidden utility

### DIFF
--- a/conViver.Web/css/components.css
+++ b/conViver.Web/css/components.css
@@ -269,6 +269,11 @@
     background-color: var(--current-color-info-bg);
     border-color: var(--current-semantic-info);
 }
+
+/* Utility class to hide alerts when needed */
+.cv-alert--hidden {
+    display: none;
+}
 /* === End Alert Component Styles === */
 
 @keyframes animatetop {

--- a/conViver.Web/forgot-password.html
+++ b/conViver.Web/forgot-password.html
@@ -18,7 +18,7 @@
                     <input type="email" id="email" name="email" class="cv-input" placeholder="seu@email.com" required>
                 </div>
                 <button type="submit" id="submitButton" class="login-form__button cv-button cv-button--primary">Enviar Link</button>
-                <div id="feedback" class="cv-alert" style="display: none; margin-top: 15px;" aria-live="polite"></div>
+                <div id="feedback" class="cv-alert cv-alert--hidden" style="margin-top: 15px;" aria-live="polite"></div>
             </form>
             <div class="login-form__links">
                 <a href="login.html" class="login-form__link">Voltar para Login</a>

--- a/conViver.Web/login.html
+++ b/conViver.Web/login.html
@@ -22,7 +22,7 @@
                     <input type="password" id="password" name="password" class="cv-input" placeholder="Sua senha" required>
                 </div>
                 <button type="submit" id="loginButton" class="login-form__button cv-button cv-button--primary">Entrar</button>
-                <div id="loginFeedback" class="cv-alert cv-alert--error" style="display: none;" aria-live="polite"></div>
+                <div id="loginFeedback" class="cv-alert cv-alert--error cv-alert--hidden" aria-live="polite"></div>
             </form>
             <div class="login-form__links">
                 <a href="forgot-password.html" class="login-form__link">Esqueceu a senha?</a>

--- a/conViver.Web/reset-password.html
+++ b/conViver.Web/reset-password.html
@@ -22,7 +22,7 @@
                     <input type="password" id="confirmPassword" name="confirmPassword" class="cv-input" placeholder="Confirme a nova senha" required>
                 </div>
                 <button type="submit" id="submitButton" class="login-form__button cv-button cv-button--primary">Redefinir Senha</button>
-                <div id="feedback" class="cv-alert" style="display: none; margin-top: 15px;" aria-live="polite"></div>
+                <div id="feedback" class="cv-alert cv-alert--hidden" style="margin-top: 15px;" aria-live="polite"></div>
             </form>
              <div class="login-form__links" id="loginLinkContainer" style="display: none;">
                 <a href="login.html" class="login-form__link">Ir para Login</a>

--- a/conViver.Web/wwwroot/css/components.css
+++ b/conViver.Web/wwwroot/css/components.css
@@ -269,6 +269,11 @@
     background-color: var(--current-color-info-bg);
     border-color: var(--current-semantic-info);
 }
+
+/* Utility class to hide alerts when needed */
+.cv-alert--hidden {
+    display: none;
+}
 /* === End Alert Component Styles === */
 
 @keyframes animatetop {

--- a/conViver.Web/wwwroot/forgot-password.html
+++ b/conViver.Web/wwwroot/forgot-password.html
@@ -18,7 +18,7 @@
                     <input type="email" id="email" name="email" class="cv-input" placeholder="seu@email.com" required>
                 </div>
                 <button type="submit" id="submitButton" class="login-form__button cv-button cv-button--primary">Enviar Link</button>
-                <div id="feedback" class="cv-alert" style="display: none; margin-top: 15px;" aria-live="polite"></div>
+                <div id="feedback" class="cv-alert cv-alert--hidden" style="margin-top: 15px;" aria-live="polite"></div>
             </form>
             <div class="login-form__links">
                 <a href="login.html" class="login-form__link">Voltar para Login</a>

--- a/conViver.Web/wwwroot/login.html
+++ b/conViver.Web/wwwroot/login.html
@@ -22,7 +22,7 @@
                     <input type="password" id="password" name="password" class="cv-input" placeholder="Sua senha" required>
                 </div>
                 <button type="submit" id="loginButton" class="login-form__button cv-button cv-button--primary">Entrar</button>
-                <div id="loginFeedback" class="cv-alert cv-alert--error" style="display: none;" aria-live="polite"></div>
+                <div id="loginFeedback" class="cv-alert cv-alert--error cv-alert--hidden" aria-live="polite"></div>
             </form>
             <div class="login-form__links">
                 <a href="forgot-password.html" class="login-form__link">Esqueceu a senha?</a>

--- a/conViver.Web/wwwroot/reset-password.html
+++ b/conViver.Web/wwwroot/reset-password.html
@@ -22,7 +22,7 @@
                     <input type="password" id="confirmPassword" name="confirmPassword" class="cv-input" placeholder="Confirme a nova senha" required>
                 </div>
                 <button type="submit" id="submitButton" class="login-form__button cv-button cv-button--primary">Redefinir Senha</button>
-                <div id="feedback" class="cv-alert" style="display: none; margin-top: 15px;" aria-live="polite"></div>
+                <div id="feedback" class="cv-alert cv-alert--hidden" style="margin-top: 15px;" aria-live="polite"></div>
             </form>
              <div class="login-form__links" id="loginLinkContainer" style="display: none;">
                 <a href="login.html" class="login-form__link">Ir para Login</a>


### PR DESCRIPTION
## Summary
- add `.cv-alert--hidden` utility class
- remove inline `display: none` styles from login, forgot password and reset password pages

## Testing
- `dotnet test conViver.Tests/conViver.Tests.csproj --no-build` *(fails: `dotnet` not found)*

------
https://chatgpt.com/codex/tasks/task_e_685dfe9f740c8332a7d810c18074c49f