### PR TITLE
Fix message banner layering

### DIFF
--- a/conViver.Web/css/styles.css
+++ b/conViver.Web/css/styles.css
@@ -766,7 +766,8 @@ main {
     background-color: #333;
     color: white;
     text-align: center;
-    z-index: 1001;
+    /* Place the banner above the sticky header (z-index: 1020) */
+    z-index: 1030;
     display: none; /* Initially hidden */
 }
 

--- a/conViver.Web/wwwroot/css/styles.css
+++ b/conViver.Web/wwwroot/css/styles.css
@@ -766,7 +766,8 @@ main {
     background-color: #333;
     color: white;
     text-align: center;
-    z-index: 1001;
+    /* Place the banner above the sticky header (z-index: 1020) */
+    z-index: 1030;
     display: none; /* Initially hidden */
 }
 


### PR DESCRIPTION
## Summary
- raise `.message-banner` z-index so it appears above `.cv-header`
- update built CSS copy in `wwwroot`

## Testing
- `dotnet test --no-build` *(fails: `dotnet` not found)*

------
https://chatgpt.com/codex/tasks/task_e_685dfeaaaa68833292c46f0be67b37fa