### PR TITLE
Add aria-current to active nav links

### DIFF
--- a/conViver.Web/js/nav.js
+++ b/conViver.Web/js/nav.js
@@ -72,6 +72,7 @@ export function buildNavigation() {
         a.className = 'cv-nav__link';
         if (currentPage === item.key || (currentPage === 'index' && item.key === 'dashboard')) {
             a.classList.add('cv-nav__link--active');
+            a.setAttribute('aria-current', 'page');
         }
         li.appendChild(a);
         ul.appendChild(li);


### PR DESCRIPTION
## Summary
- improve nav accessibility by adding `aria-current="page"` when a nav item is active

## Testing
- `dotnet test conViver.Tests/conViver.Tests.csproj --configuration Release` *(fails: Program is inaccessible)*

------
https://chatgpt.com/codex/tasks/task_e_685dfe87ee88833298551fdd59de73fc