### PR TITLE
Fix navigation routes to always load via layout

### DIFF
--- a/conViver.Web/js/nav.js
+++ b/conViver.Web/js/nav.js
@@ -3,7 +3,6 @@ export function buildNavigation() {
     if (!navContainer) return;
 
     const isInPagesDir = window.location.pathname.includes('/pages/');
-    const hrefPrefix = isInPagesDir ? '' : 'pages/';
     const layoutPrefix = isInPagesDir ? '../layout.html?page=' : 'layout.html?page=';
 
     const urlParams = new URLSearchParams(window.location.search);
@@ -15,43 +14,33 @@ export function buildNavigation() {
         {
             key: 'dashboard',
             label: 'Dashboard',
-            href: 'dashboard.html',
             icon: `<svg class="cv-nav__icon" xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M3 9l9-7 9 7v11a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2z"/><polyline points="9 22 9 12 15 12 15 22"/></svg>`
         },
         {
             key: 'financeiro',
             label: 'Financeiro',
-            href: 'financeiro.html',
             icon: `<svg class="cv-nav__icon" xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><line x1="12" y1="1" x2="12" y2="23"/><path d="M17 5H9.5a3.5 3.5 0 0 0 0 7h5a3.5 3.5 0 0 1 0 7H6"/></svg>`
         },
         {
             key: 'reservas',
             label: 'Reservas',
-            href: 'reservas.html',
-            useLayout: true,
             icon: `<svg class="cv-nav__icon" xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="3" y="4" width="18" height="18" rx="2" ry="2"/><line x1="16" y1="2" x2="16" y2="6"/><line x1="8" y1="2" x2="8" y2="6"/><line x1="3" y1="10" x2="21" y2="10"/></svg>`
         },
         {
             key: 'portaria',
             label: 'Portaria',
-            href: 'portaria.html',
-            useLayout: true,
             icon: `<svg class="cv-nav__icon" width="24" height="24" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M21 2l-2 2m-7.61 7.61a5.5 5.5 0 1 1-7.778 7.778 5.5 5.5 0 0 1 7.777-7.777zm0 0L15.5 7.5m0 0l3 3L22 7l-3-3m-3.5 3.5L19 4"/></svg>`
         },
         {
             key: 'comunicacao',
             label: 'Comunicação',
-            href: 'comunicacao.html',
-            useLayout: true,
             icon: `<svg class="cv-nav__icon" xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M21 11.5a8.38 8.38 0 0 1-.9 3.8 8.5 8.5 0 0 1-7.6 4.7 8.38 8.38 0 0 1-3.8-.9L3 21l1.9-5.7a8.38 8.38 0 0 1-.9-3.8 8.5 8.5 0 0 1 4.7-7.6 8.38 8.38 0 0 1 3.8-.9h.5a8.48 8.48 0 0 1 8 8v.5z"/></svg>`
         },
         // { key: 'ocorrencias', label: 'Ocorrências', href: 'ocorrencias.html' }, // Removido
         {
             key: 'biblioteca',
             label: 'Biblioteca',
-            href: 'biblioteca.html',
             icon: `<svg class="cv-nav__icon" xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M4 19.5A2.5 2.5 0 0 1 6.5 17H20"/><path d="M6.5 2H20v20H6.5A2.5 2.5 0 0 1 4 19.5v-15A2.5 2.5 0 0 1 6.5 2z"/></svg>`
-        }
     ];
 
     const container = document.createElement('div');
@@ -63,11 +52,7 @@ export function buildNavigation() {
         const li = document.createElement('li');
         li.className = 'cv-nav__item';
         const a = document.createElement('a');
-        if (item.useLayout) {
-            a.href = `${layoutPrefix}${item.key}`;
-        } else {
-            a.href = `${hrefPrefix}${item.href}`;
-        }
+        a.href = `${layoutPrefix}${item.key}`;
         a.innerHTML = `${item.icon}<span class="cv-nav__label">${item.label}</span>`;
         a.className = 'cv-nav__link';
         if (currentPage === item.key || (currentPage === 'index' && item.key === 'dashboard')) {

--- a/conViver.Web/wwwroot/js/nav.js
+++ b/conViver.Web/wwwroot/js/nav.js
@@ -3,7 +3,6 @@ export function buildNavigation() {
     if (!navContainer) return;
 
     const isInPagesDir = window.location.pathname.includes('/pages/');
-    const hrefPrefix = isInPagesDir ? '' : 'pages/';
     const layoutPrefix = isInPagesDir ? '../layout.html?page=' : 'layout.html?page=';
 
     const urlParams = new URLSearchParams(window.location.search);
@@ -15,43 +14,33 @@ export function buildNavigation() {
         {
             key: 'dashboard',
             label: 'Dashboard',
-            href: 'dashboard.html',
             icon: `<svg class="cv-nav__icon" xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M3 9l9-7 9 7v11a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2z"/><polyline points="9 22 9 12 15 12 15 22"/></svg>`
         },
         {
             key: 'financeiro',
             label: 'Financeiro',
-            href: 'financeiro.html',
             icon: `<svg class="cv-nav__icon" xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><line x1="12" y1="1" x2="12" y2="23"/><path d="M17 5H9.5a3.5 3.5 0 0 0 0 7h5a3.5 3.5 0 0 1 0 7H6"/></svg>`
         },
         {
             key: 'reservas',
             label: 'Reservas',
-            href: 'reservas.html',
-            useLayout: true,
             icon: `<svg class="cv-nav__icon" xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="3" y="4" width="18" height="18" rx="2" ry="2"/><line x1="16" y1="2" x2="16" y2="6"/><line x1="8" y1="2" x2="8" y2="6"/><line x1="3" y1="10" x2="21" y2="10"/></svg>`
         },
         {
             key: 'portaria',
             label: 'Portaria',
-            href: 'portaria.html',
-            useLayout: true,
             icon: `<svg class="cv-nav__icon" width="24" height="24" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M21 2l-2 2m-7.61 7.61a5.5 5.5 0 1 1-7.778 7.778 5.5 5.5 0 0 1 7.777-7.777zm0 0L15.5 7.5m0 0l3 3L22 7l-3-3m-3.5 3.5L19 4"/></svg>`
         },
         {
             key: 'comunicacao',
             label: 'Comunicação',
-            href: 'comunicacao.html',
-            useLayout: true,
             icon: `<svg class="cv-nav__icon" xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M21 11.5a8.38 8.38 0 0 1-.9 3.8 8.5 8.5 0 0 1-7.6 4.7 8.38 8.38 0 0 1-3.8-.9L3 21l1.9-5.7a8.38 8.38 0 0 1-.9-3.8 8.5 8.5 0 0 1 4.7-7.6 8.38 8.38 0 0 1 3.8-.9h.5a8.48 8.48 0 0 1 8 8v.5z"/></svg>`
         },
         // { key: 'ocorrencias', label: 'Ocorrências', href: 'ocorrencias.html' }, // Removido
         {
             key: 'biblioteca',
             label: 'Biblioteca',
-            href: 'biblioteca.html',
             icon: `<svg class="cv-nav__icon" xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M4 19.5A2.5 2.5 0 0 1 6.5 17H20"/><path d="M6.5 2H20v20H6.5A2.5 2.5 0 0 1 4 19.5v-15A2.5 2.5 0 0 1 6.5 2z"/></svg>`
-        }
     ];
 
     const container = document.createElement('div');
@@ -63,15 +52,12 @@ export function buildNavigation() {
         const li = document.createElement('li');
         li.className = 'cv-nav__item';
         const a = document.createElement('a');
-        if (item.useLayout) {
-            a.href = `${layoutPrefix}${item.key}`;
-        } else {
-            a.href = `${hrefPrefix}${item.href}`;
-        }
+        a.href = `${layoutPrefix}${item.key}`;
         a.innerHTML = `${item.icon}<span class="cv-nav__label">${item.label}</span>`;
         a.className = 'cv-nav__link';
         if (currentPage === item.key || (currentPage === 'index' && item.key === 'dashboard')) {
             a.classList.add('cv-nav__link--active');
+            a.setAttribute('aria-current', 'page');
         }
         li.appendChild(a);
         ul.appendChild(li);

--- a/conViver.Web/wwwroot/layout.html
+++ b/conViver.Web/wwwroot/layout.html
@@ -1,0 +1,35 @@
+<!DOCTYPE html>
+<html lang="pt-BR">
+<head>
+    <meta charset="UTF-8">
+    <title>conViver</title>
+    <link rel="stylesheet" href="css/components.css">
+    <link rel="stylesheet" href="css/styles.css">
+</head>
+<body>
+    <div id="global-message-banner" class="message-banner"></div>
+    <header class="cv-header">
+        <div class="cv-container cv-header__container">
+            <h1 class="cv-header__title">conViver</h1>
+            <button id="userMenuButton" class="user-avatar"></button>
+        </div>
+    </header>
+    <div id="userMenuModal" class="cv-modal user-menu-modal">
+        <div class="cv-modal-content">
+            <span class="cv-modal-close" id="userMenuClose">&times;</span>
+            <ul class="user-menu-list">
+                <li><button id="toggleThemeButton" class="cv-button">Alterar Tema</button></li>
+                <li><button id="goProfileButton" class="cv-button">Gerenciar Perfil</button></li>
+                <li><button id="userLogoutButton" class="cv-button">Logout</button></li>
+            </ul>
+        </div>
+    </div>
+    <nav id="mainNav"></nav>
+    <main id="pageMain" class="cv-container"></main>
+    <script src="js/config.js"></script>
+    <script type="module" src="js/nav.js"></script>
+    <script type="module" src="js/userMenu.js"></script>
+    <script type="module" src="js/main.js"></script>
+    <script type="module" src="js/pageLoader.js"></script>
+</body>
+</html>

--- a/scripts/sync_wwwroot.sh
+++ b/scripts/sync_wwwroot.sh
@@ -12,5 +12,6 @@ rsync -a --delete "$WEB_DIR/js/" "$WEB_DIR/wwwroot/js/"
 
 # Also copy top-level html files
 rsync -a "$WEB_DIR/index.html" "$WEB_DIR/login.html" "$WEB_DIR/forgot-password.html" \
-      "$WEB_DIR/register.html" "$WEB_DIR/reset-password.html" "$WEB_DIR/wwwroot/"
+      "$WEB_DIR/register.html" "$WEB_DIR/reset-password.html" "$WEB_DIR/layout.html" \
+      "$WEB_DIR/wwwroot/"
 


### PR DESCRIPTION
## Summary
- update sync script to copy layout.html
- add layout.html to wwwroot
- simplify nav.js to always build links using layout.html?page=KEY
- replicate changes to built JS in wwwroot

## Testing
- `dotnet build --no-restore` *(fails: command not found)*
- `bash scripts/sync_wwwroot.sh`

------
https://chatgpt.com/codex/tasks/task_e_685e05a487688332a7fd3000a0d8b91d