### PR TITLE
Fix sync script to include layout.html

### DIFF
--- a/scripts/sync_wwwroot.sh
+++ b/scripts/sync_wwwroot.sh
@@ -12,5 +12,5 @@ rsync -a --delete "$WEB_DIR/js/" "$WEB_DIR/wwwroot/js/"
 
 # Also copy top-level html files
 rsync -a "$WEB_DIR/index.html" "$WEB_DIR/login.html" "$WEB_DIR/forgot-password.html" \
-      "$WEB_DIR/register.html" "$WEB_DIR/reset-password.html" "$WEB_DIR/wwwroot/"
+      "$WEB_DIR/register.html" "$WEB_DIR/reset-password.html" "$WEB_DIR/layout.html" "$WEB_DIR/wwwroot/"
 


### PR DESCRIPTION
## Summary
- update `sync_wwwroot.sh` to copy `layout.html`

## Testing
- `bash scripts/sync_wwwroot.sh`
- `dotnet test conViver.Tests/conViver.Tests.csproj --verbosity minimal` *(fails: `Program is inaccessible`)*

------
https://chatgpt.com/codex/tasks/task_e_685e9439bde483329db52717e8321261