### PR TITLE
Add status badges with icons

### DIFF
--- a/conViver.Web/css/components.css
+++ b/conViver.Web/css/components.css
@@ -599,3 +599,33 @@ html[data-theme="dark"] {
 }
 */
 
+/* === Status Badge Utility Classes === */
+.status-badge {
+    display: inline-flex;
+    align-items: center;
+    gap: 4px;
+    font-size: 0.75rem;
+    font-weight: 600;
+    padding: 2px 6px;
+    border-radius: var(--cv-border-radius-sm, 4px);
+}
+.status-icon {
+    font-size: 0.8em;
+    line-height: 1;
+}
+.status-icon.icon-success::before { content: "✅"; }
+.status-icon.icon-warning::before { content: "⚠️"; }
+.status-icon.icon-danger::before { content: "❌"; }
+.status-badge--success {
+    background-color: var(--current-color-success-bg);
+    color: var(--current-semantic-success);
+}
+.status-badge--warning {
+    background-color: var(--current-color-warning-bg);
+    color: var(--current-semantic-warning);
+}
+.status-badge--danger {
+    background-color: var(--current-color-error-bg);
+    color: var(--current-semantic-error);
+}
+/* === End Status Badge Utility Classes === */

--- a/conViver.Web/js/financeiro.js
+++ b/conViver.Web/js/financeiro.js
@@ -3,7 +3,16 @@ import { requireAuth } from './auth.js';
 import { formatCurrency, formatDate, showGlobalFeedback } from './main.js'; // Updated import
 import { showFeedSkeleton, hideFeedSkeleton } from './skeleton.js';
 
+function getStatusBadgeHtml(status) {
+    const s = status ? status.toLowerCase() : "";
+    let type = "success";
+    if (s.includes("pendente") || s.includes("aguardando")) type = "warning";
+    else if (s.includes("cancel") || s.includes("recus") || s.includes("vencid") || s.includes("extraviad") || s.includes("devolvid")) type = "danger";
+    return `<span class="status-badge status-badge--${type}"><span class="status-icon icon-${type}"></span>${status}</span>`;
+}
+
 document.addEventListener('DOMContentLoaded', () => {
+
     requireAuth();
 
     // DOM Elements
@@ -295,9 +304,8 @@ document.addEventListener('DOMContentLoaded', () => {
             tr.insertCell().textContent = formatDate(new Date(cobranca.dataVencimento));
 
             const statusCell = tr.insertCell();
-            statusCell.textContent = cobranca.statusCobranca;
-            statusCell.className = `status-${cobranca.statusCobranca.toLowerCase().replace(/\s+/g, '-')}`;
 
+            statusCell.innerHTML = getStatusBadgeHtml(cobranca.statusCobranca);
 
             const acoesCell = tr.insertCell();
             acoesCell.innerHTML = `

--- a/conViver.Web/js/portaria.js
+++ b/conViver.Web/js/portaria.js
@@ -5,6 +5,14 @@ import { initFabMenu } from './fabMenu.js';
 import { showFeedSkeleton, hideFeedSkeleton } from './skeleton.js';
 
 // --- Configuração das Abas Principais ---
+function getStatusBadgeHtml(status) {
+    const s = status ? status.toLowerCase() : "";
+    let type = "success";
+    if (s.includes("pendente") || s.includes("aguardando")) type = "warning";
+    else if (s.includes("cancel") || s.includes("recus") || s.includes("vencid") || s.includes("extraviad") || s.includes("devolvid")) type = "danger";
+    return `<span class="status-badge status-badge--${type}"><span class="status-icon icon-${type}"></span>${status}</span>`;
+}
+
 function setupMainTabs() {
     const mainTabButtons = document.querySelectorAll('main > .cv-tabs .cv-tab-button');
     const mainTabContents = document.querySelectorAll('main > .cv-tab-content');
@@ -314,7 +322,7 @@ async function carregarHistoricoVisitantes(filters = {}) {
                     <td>${v.motivoVisita || ''}</td>
                     <td>${new Date(v.dataChegada).toLocaleString()}</td>
                     <td>${v.dataSaida ? new Date(v.dataSaida).toLocaleString() : 'Presente'}</td>
-                    <td>${v.status}</td>
+                    <td>${getStatusBadgeHtml(v.status)}</td>
                     <td>${v.observacoes || ''}</td>
                 `;
                 historicoTbody.appendChild(tr);
@@ -424,7 +432,7 @@ async function carregarEncomendas() {
                 const tr = document.createElement('tr');
                 const status = e.status || (e.retiradoEm ? 'Retirada' : 'Aguardando');
                 const btn = e.retiradoEm ? '' : `<button class="cv-button cv-button--small btn-retirar" data-id="${e.id}">Confirmar Retirada</button>`;
-                tr.innerHTML = `<td>${e.descricao || ''}</td><td>${e.unidadeId.slice(0,8)}...</td><td>${status}</td><td>${btn}</td>`;
+                tr.innerHTML = `<td>${e.descricao || ''}</td><td>${e.unidadeId.slice(0,8)}...</td><td>${getStatusBadgeHtml(status)}</td><td>${btn}</td>`;
                 tbody.appendChild(tr);
             });
         } else {

--- a/conViver.Web/js/reservas.js
+++ b/conViver.Web/js/reservas.js
@@ -18,6 +18,14 @@ let currentUserId = null;
 let currentUserRoles = [];
 let agendaDiaListContainer, agendaDiaLoading, agendaDiaSkeleton;
 let dataSelecionadaAgenda = new Date().toISOString().split("T")[0];
+function getStatusBadgeHtml(status) {
+  const s = status ? status.toLowerCase() : "";
+  let type = "success";
+  if (s.includes("pendente") || s.includes("aguardando")) type = "warning";
+  else if (s.includes("cancel") || s.includes("recus") || s.includes("vencid") || s.includes("extraviad") || s.includes("devolvid")) type = "danger";
+  return `<span class="status-badge status-badge--${type}"><span class="status-icon icon-${type}"></span>${status}</span>`;
+}
+
 
 // List View (Agenda Tab)
 let currentPageListView = 1;
@@ -796,21 +804,10 @@ function renderCardReservaListView(reserva) {
   });
   const fimFmt = new Date(reserva.fim).toLocaleString("pt-BR", {
     hour: "2-digit",
-    minute: "2-digit",
-  });
-
-  let statusClass = "";
-  if (reserva.status === "Confirmada") statusClass = "cv-text-success";
-  else if (reserva.status === "Pendente") statusClass = "cv-text-warning";
-  else if (reserva.status.startsWith("Cancelada"))
-    statusClass = "cv-text-error";
-
   card.innerHTML = `
     <h3>${reserva.nomeEspacoComum}</h3>
     <p><strong>Data:</strong> ${inicioFmt} - ${fimFmt}</p>
-    <p><strong>Status:</strong> <span class="${statusClass}">${
-    reserva.status
-  }</span></p>
+    <p><strong>Status:</strong> ${getStatusBadgeHtml(reserva.status)}</p>
     <p><strong>Solicitante:</strong> ${
       reserva.nomeUsuarioSolicitante || reserva.nomeUnidade || "N/A"
     }</p>

--- a/conViver.Web/wwwroot/css/components.css
+++ b/conViver.Web/wwwroot/css/components.css
@@ -599,3 +599,33 @@ html[data-theme="dark"] {
 }
 */
 
+/* === Status Badge Utility Classes === */
+.status-badge {
+    display: inline-flex;
+    align-items: center;
+    gap: 4px;
+    font-size: 0.75rem;
+    font-weight: 600;
+    padding: 2px 6px;
+    border-radius: var(--cv-border-radius-sm, 4px);
+}
+.status-icon {
+    font-size: 0.8em;
+    line-height: 1;
+}
+.status-icon.icon-success::before { content: "✅"; }
+.status-icon.icon-warning::before { content: "⚠️"; }
+.status-icon.icon-danger::before { content: "❌"; }
+.status-badge--success {
+    background-color: var(--current-color-success-bg);
+    color: var(--current-semantic-success);
+}
+.status-badge--warning {
+    background-color: var(--current-color-warning-bg);
+    color: var(--current-semantic-warning);
+}
+.status-badge--danger {
+    background-color: var(--current-color-error-bg);
+    color: var(--current-semantic-error);
+}
+/* === End Status Badge Utility Classes === */

--- a/conViver.Web/wwwroot/js/financeiro.js
+++ b/conViver.Web/wwwroot/js/financeiro.js
@@ -3,7 +3,16 @@ import { requireAuth } from './auth.js';
 import { formatCurrency, formatDate, showGlobalFeedback } from './main.js'; // Updated import
 import { showFeedSkeleton, hideFeedSkeleton } from './skeleton.js';
 
+function getStatusBadgeHtml(status) {
+    const s = status ? status.toLowerCase() : "";
+    let type = "success";
+    if (s.includes("pendente") || s.includes("aguardando")) type = "warning";
+    else if (s.includes("cancel") || s.includes("recus") || s.includes("vencid") || s.includes("extraviad") || s.includes("devolvid")) type = "danger";
+    return `<span class="status-badge status-badge--${type}"><span class="status-icon icon-${type}"></span>${status}</span>`;
+}
+
 document.addEventListener('DOMContentLoaded', () => {
+
     requireAuth();
 
     // DOM Elements
@@ -295,9 +304,8 @@ document.addEventListener('DOMContentLoaded', () => {
             tr.insertCell().textContent = formatDate(new Date(cobranca.dataVencimento));
 
             const statusCell = tr.insertCell();
-            statusCell.textContent = cobranca.statusCobranca;
-            statusCell.className = `status-${cobranca.statusCobranca.toLowerCase().replace(/\s+/g, '-')}`;
 
+            statusCell.innerHTML = getStatusBadgeHtml(cobranca.statusCobranca);
 
             const acoesCell = tr.insertCell();
             acoesCell.innerHTML = `

--- a/conViver.Web/wwwroot/js/portaria.js
+++ b/conViver.Web/wwwroot/js/portaria.js
@@ -5,6 +5,14 @@ import { initFabMenu } from './fabMenu.js';
 import { showFeedSkeleton, hideFeedSkeleton } from './skeleton.js';
 
 // --- Configuração das Abas Principais ---
+function getStatusBadgeHtml(status) {
+    const s = status ? status.toLowerCase() : "";
+    let type = "success";
+    if (s.includes("pendente") || s.includes("aguardando")) type = "warning";
+    else if (s.includes("cancel") || s.includes("recus") || s.includes("vencid") || s.includes("extraviad") || s.includes("devolvid")) type = "danger";
+    return `<span class="status-badge status-badge--${type}"><span class="status-icon icon-${type}"></span>${status}</span>`;
+}
+
 function setupMainTabs() {
     const mainTabButtons = document.querySelectorAll('main > .cv-tabs .cv-tab-button');
     const mainTabContents = document.querySelectorAll('main > .cv-tab-content');
@@ -134,7 +142,7 @@ async function carregarVisitantesAtuais(unidadeFilter = '') {
     // showGlobalFeedback('Carregando visitantes atuais...', 'info');
 
     try {
-        let url = '/api/visitantes/atuais';
+        let url = '/api/v1/visitantes/atuais';
         // Filtering by unidadeFilter (string for unit name) is deferred as API expects Guid.
         // if (unidadeFilter) {
         //     url += `?unidadeNome=${encodeURIComponent(unidadeFilter)}`; // Example if API supported name filter
@@ -183,7 +191,7 @@ function adicionarListenersSaida() {
             const visitanteId = event.target.dataset.id;
             if (confirm(`Deseja realmente registrar a saída do visitante?`)) {
                 try {
-                    await apiClient.post(`/api/visitantes/${visitanteId}/registrar-saida`, {});
+                    await apiClient.post(`/api/v1/visitantes/${visitanteId}/registrar-saida`, {});
                     carregarVisitantesAtuais(); // Refresh the list
                 } catch (err) {
                     console.error('Erro ao registrar saída:', err);
@@ -218,7 +226,7 @@ if (formRegistrarVisitante && registrarVisitanteMsg) {
         registrarVisitanteMsg.textContent = 'Registrando entrada...';
 
         try {
-            const response = await apiClient.post('/api/visitantes/registrar-entrada', data);
+            const response = await apiClient.post('/api/v1/visitantes/registrar-entrada', data);
             registrarVisitanteMsg.className = 'feedback-message success';
             registrarVisitanteMsg.textContent = 'Entrada registrada com sucesso! ID: ' + response.id;
             formRegistrarVisitante.reset();
@@ -250,7 +258,7 @@ if (btnValidarQRCode && registrarVisitanteMsg && formRegistrarVisitante) {
 
 
         try {
-            const response = await apiClient.post('/api/visitantes/validar-qr-code', { qrCodeValue });
+            const response = await apiClient.post('/api/v1/visitantes/validar-qr-code', { qrCodeValue });
             registrarVisitanteMsg.className = 'feedback-message success';
             registrarVisitanteMsg.textContent = `Entrada por QR Code validada para: ${response.nome}. Status: ${response.status}`;
 
@@ -299,7 +307,7 @@ async function carregarHistoricoVisitantes(filters = {}) {
         if (filters.fim) params.append('fim', filters.fim);
         if (filters.nomeVisitante) params.append('nomeVisitante', filters.nomeVisitante);
 
-        const url = `/api/visitantes/historico?${params.toString()}`;
+        const url = `/api/v1/visitantes/historico?${params.toString()}`;
         const visitas = await apiClient.get(url);
 
         historicoLoadingMsg.style.display = 'none';
@@ -314,7 +322,7 @@ async function carregarHistoricoVisitantes(filters = {}) {
                     <td>${v.motivoVisita || ''}</td>
                     <td>${new Date(v.dataChegada).toLocaleString()}</td>
                     <td>${v.dataSaida ? new Date(v.dataSaida).toLocaleString() : 'Presente'}</td>
-                    <td>${v.status}</td>
+                    <td>${getStatusBadgeHtml(v.status)}</td>
                     <td>${v.observacoes || ''}</td>
                 `;
                 historicoTbody.appendChild(tr);
@@ -424,7 +432,7 @@ async function carregarEncomendas() {
                 const tr = document.createElement('tr');
                 const status = e.status || (e.retiradoEm ? 'Retirada' : 'Aguardando');
                 const btn = e.retiradoEm ? '' : `<button class="cv-button cv-button--small btn-retirar" data-id="${e.id}">Confirmar Retirada</button>`;
-                tr.innerHTML = `<td>${e.descricao || ''}</td><td>${e.unidadeId.slice(0,8)}...</td><td>${status}</td><td>${btn}</td>`;
+                tr.innerHTML = `<td>${e.descricao || ''}</td><td>${e.unidadeId.slice(0,8)}...</td><td>${getStatusBadgeHtml(status)}</td><td>${btn}</td>`;
                 tbody.appendChild(tr);
             });
         } else {

--- a/conViver.Web/wwwroot/js/reservas.js
+++ b/conViver.Web/wwwroot/js/reservas.js
@@ -18,6 +18,14 @@ let currentUserId = null;
 let currentUserRoles = [];
 let agendaDiaListContainer, agendaDiaLoading, agendaDiaSkeleton;
 let dataSelecionadaAgenda = new Date().toISOString().split("T")[0];
+function getStatusBadgeHtml(status) {
+  const s = status ? status.toLowerCase() : "";
+  let type = "success";
+  if (s.includes("pendente") || s.includes("aguardando")) type = "warning";
+  else if (s.includes("cancel") || s.includes("recus") || s.includes("vencid") || s.includes("extraviad") || s.includes("devolvid")) type = "danger";
+  return `<span class="status-badge status-badge--${type}"><span class="status-icon icon-${type}"></span>${status}</span>`;
+}
+
 
 // List View (Agenda Tab)
 let currentPageListView = 1;
@@ -796,21 +804,10 @@ function renderCardReservaListView(reserva) {
   });
   const fimFmt = new Date(reserva.fim).toLocaleString("pt-BR", {
     hour: "2-digit",
-    minute: "2-digit",
-  });
-
-  let statusClass = "";
-  if (reserva.status === "Confirmada") statusClass = "cv-text-success";
-  else if (reserva.status === "Pendente") statusClass = "cv-text-warning";
-  else if (reserva.status.startsWith("Cancelada"))
-    statusClass = "cv-text-error";
-
   card.innerHTML = `
     <h3>${reserva.nomeEspacoComum}</h3>
     <p><strong>Data:</strong> ${inicioFmt} - ${fimFmt}</p>
-    <p><strong>Status:</strong> <span class="${statusClass}">${
-    reserva.status
-  }</span></p>
+    <p><strong>Status:</strong> ${getStatusBadgeHtml(reserva.status)}</p>
     <p><strong>Solicitante:</strong> ${
       reserva.nomeUsuarioSolicitante || reserva.nomeUnidade || "N/A"
     }</p>


### PR DESCRIPTION
## Summary
- extend components.css with reusable status badges and icons
- show colored badges in portaria, financeiro and reservas modules
- sync compiled assets into wwwroot

## Testing
- `~/.dotnet/dotnet format --verify-no-changes -v diag`
- `~/.dotnet/dotnet test conViver.Tests/conViver.Tests.csproj --no-build` *(fails: invalid argument)*

------
https://chatgpt.com/codex/tasks/task_e_685ef7a311808332a161bbbacf9a0445