### PR TITLE
Fix reservas tab isolation

### DIFF
--- a/conViver.Web/js/reservas.js
+++ b/conViver.Web/js/reservas.js
@@ -507,8 +507,11 @@ function toggleReservasView(view) {
 }
 
 function setupTabs() {
-  const tabButtons = document.querySelectorAll(".cv-tab-button");
-  const tabContents = document.querySelectorAll(".cv-tab-content");
+  const tabsContainer = document.getElementById("reservas-tabs");
+  const tabButtons = tabsContainer.querySelectorAll(".cv-tab-button");
+  const tabContents = tabsContainer.parentElement.querySelectorAll(
+    ".cv-tab-content"
+  );
   tabButtons.forEach((button) => {
     button.addEventListener("click", () => {
       console.log(`Tab clicked: ${button.id}`); // Log: Tab button ID
@@ -564,7 +567,7 @@ function setupTabs() {
   });
 
   const initialActive =
-    document.querySelector(".cv-tab-button.active") || tabButtons[0];
+    tabsContainer.querySelector(".cv-tab-button.active") || tabButtons[0];
   if (initialActive) initialActive.click(); // This will trigger the specific logic above for the initially active tab.
 }
 

--- a/conViver.Web/pages/reservas.html
+++ b/conViver.Web/pages/reservas.html
@@ -1,4 +1,4 @@
-        <div class="cv-tabs">
+        <div class="cv-tabs" id="reservas-tabs">
             <div class="cv-tabs-buttons">
                 <button class="cv-tab-button active" id="tab-agenda">Agenda e Disponibilidade</button>
                 <button class="cv-tab-button" id="tab-minhas-reservas">Minhas Reservas</button>

--- a/conViver.Web/wwwroot/js/reservas.js
+++ b/conViver.Web/wwwroot/js/reservas.js
@@ -507,8 +507,11 @@ function toggleReservasView(view) {
 }
 
 function setupTabs() {
-  const tabButtons = document.querySelectorAll(".cv-tab-button");
-  const tabContents = document.querySelectorAll(".cv-tab-content");
+  const tabsContainer = document.getElementById("reservas-tabs");
+  const tabButtons = tabsContainer.querySelectorAll(".cv-tab-button");
+  const tabContents = tabsContainer.parentElement.querySelectorAll(
+    ".cv-tab-content"
+  );
   tabButtons.forEach((button) => {
     button.addEventListener("click", () => {
       console.log(`Tab clicked: ${button.id}`); // Log: Tab button ID
@@ -564,7 +567,7 @@ function setupTabs() {
   });
 
   const initialActive =
-    document.querySelector(".cv-tab-button.active") || tabButtons[0];
+    tabsContainer.querySelector(".cv-tab-button.active") || tabButtons[0];
   if (initialActive) initialActive.click(); // This will trigger the specific logic above for the initially active tab.
 }
 

--- a/conViver.Web/wwwroot/pages/reservas.html
+++ b/conViver.Web/wwwroot/pages/reservas.html
@@ -1,4 +1,4 @@
-        <div class="cv-tabs">
+        <div class="cv-tabs" id="reservas-tabs">
             <div class="cv-tabs-buttons">
                 <button class="cv-tab-button active" id="tab-agenda">Agenda e Disponibilidade</button>
                 <button class="cv-tab-button" id="tab-minhas-reservas">Minhas Reservas</button>


### PR DESCRIPTION
## Summary
- give the reservations tab container an id
- scope tab logic to this container so other pages are not affected

## Testing
- `dotnet test --no-build` *(fails: `dotnet` command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685efee8e3f48332b0f216c2c097f96e