### PR TITLE
Enhance communication module filters and sorting

### DIFF
--- a/conViver.API/Controllers/FeedController.cs
+++ b/conViver.API/Controllers/FeedController.cs
@@ -28,7 +28,9 @@ namespace conViver.API.Controllers
             [FromQuery] int pageSize = 10,
             [FromQuery] string? categoria = null,
             [FromQuery] DateTime? periodoInicio = null,
-            [FromQuery] DateTime? periodoFim = null)
+            [FromQuery] DateTime? periodoFim = null,
+            [FromQuery] string? status = null,
+            [FromQuery] bool? minhas = null)
         {
             var userIdClaim = User.FindFirstValue(ClaimTypes.NameIdentifier);
             var condominioIdClaim = User.FindFirstValue("condominioId");
@@ -46,7 +48,7 @@ namespace conViver.API.Controllers
 
             try
             {
-                var feedItems = await _feedService.GetFeedAsync(condominioId, userId, pageNumber, pageSize, categoria, periodoInicio, periodoFim, HttpContext.RequestAborted);
+                var feedItems = await _feedService.GetFeedAsync(condominioId, userId, pageNumber, pageSize, categoria, periodoInicio, periodoFim, status, minhas, HttpContext.RequestAborted);
 
                 // If feedItems is null or empty, returning Ok with an empty list is standard.
                 // The frontend can then decide how to display "no items found".

--- a/conViver.Application/Services/VotacaoService.cs
+++ b/conViver.Application/Services/VotacaoService.cs
@@ -64,7 +64,8 @@ public class VotacaoService
                 Titulo = v.Titulo,
                 DataInicio = v.DataInicio,
                 DataFim = v.DataFim,
-                Status = v.Status
+                Status = v.Status,
+                CriadoPor = v.CriadoPor
             })
             .ToListAsync(ct);
     }

--- a/conViver.Core/DTOs/FeedItemDto.cs
+++ b/conViver.Core/DTOs/FeedItemDto.cs
@@ -6,6 +6,7 @@ namespace conViver.Core.DTOs
     {
         public string ItemType { get; set; } = string.Empty; // e.g., "Aviso", "Enquete", "Chamado", "Ocorrencia", "Documento", "Encomenda", "BoletoLembrete", "Reserva"
         public Guid Id { get; set; } // Original ID of the item
+        public Guid CriadoPor { get; set; } // Autor ou criador do item
         public string Titulo { get; set; } = string.Empty;
         public string Resumo { get; set; } = string.Empty; // A short description or snippet
         public DateTime DataHoraPrincipal { get; set; } // The main date/time for sorting, e.g., DataPublicacao, DataAbertura, DataVencimento

--- a/conViver.Core/DTOs/VotacaoDtos.cs
+++ b/conViver.Core/DTOs/VotacaoDtos.cs
@@ -56,6 +56,7 @@ public class VotacaoResumoDto
     public DateTime DataInicio { get; set; }
     public DateTime? DataFim { get; set; }
     public string Status { get; set; } = string.Empty; // Aberta, Encerrada, Apurada
+    public Guid CriadoPor { get; set; }
 }
 
 public class VotoInputDto

--- a/conViver.Web/css/styles.css
+++ b/conViver.Web/css/styles.css
@@ -790,9 +790,11 @@ main {
     margin-bottom: 20px;
     border-bottom: 2px solid var(--current-border-subtle, #eee); /* Use variable or fallback */
 }
-.cv-tabs > #open-filter-reservas-button,
-.cv-tabs > #open-filter-modal-button {
+.cv-tabs > #open-sort-button {
     margin-left: auto;
+}
+.cv-tabs > #open-filter-modal-button {
+    margin-left: 10px;
 }
 
 .cv-tab-button {

--- a/conViver.Web/pages/comunicacao.html
+++ b/conViver.Web/pages/comunicacao.html
@@ -5,6 +5,11 @@
                 <button class="cv-tab-button" id="tab-solicitacoes">Solicitações</button>
                 <button class="cv-tab-button" id="tab-ocorrencias">Ocorrências</button>
             </div>
+            <button id="open-sort-button" class="cv-button icon-button" title="Ordenar">
+                <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+                    <polyline points="6 9 12 15 18 9"></polyline>
+                </svg>
+            </button>
             <button id="open-filter-modal-button" class="cv-button icon-button" title="Filtros">
                 <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
                     <polygon points="22 3 2 3 10 12.46 10 19 14 21 14 12.46 22 3"></polygon>
@@ -30,7 +35,7 @@
                 <div class="cv-card feed-skeleton-item"><div class="skeleton-title"></div><div class="skeleton-line"></div><div class="skeleton-line short"></div></div>
             </div>
             <p class="cv-info-message" style="padding: 20px; text-align: center;">
-                As enquetes são exibidas no Mural principal.
+                Nenhuma enquete encontrada para os filtros atuais.
                 <span class="js-sindico-only-message" style="display:none;">Use o botão (+) para criar uma nova enquete.</span>
             </p>
         </div>
@@ -85,9 +90,79 @@
                     <label for="period-filter-modal">Período (Mês/Ano):</label>
                     <input type="month" id="period-filter-modal" name="period-filter-modal" class="cv-input">
                 </div>
+                <div class="cv-form-group" data-filter-context="enquetes" style="display:none;">
+                    <label for="enquete-author-filter">Autor:</label>
+                    <select id="enquete-author-filter" class="cv-input">
+                        <option value="todas">Todas</option>
+                        <option value="minhas">Minhas</option>
+                    </select>
+                </div>
+                <div class="cv-form-group" data-filter-context="enquetes" style="display:none;">
+                    <label for="enquete-status-filter">Situação:</label>
+                    <select id="enquete-status-filter" class="cv-input">
+                        <option value="">Todas</option>
+                        <option value="Aberta">Em Aberto</option>
+                        <option value="Concluida">Concluídas</option>
+                        <option value="Cancelada">Canceladas</option>
+                    </select>
+                </div>
+                <div class="cv-form-group" data-filter-context="solicitacoes" style="display:none;">
+                    <label for="solicitacao-author-filter">Autor:</label>
+                    <select id="solicitacao-author-filter" class="cv-input">
+                        <option value="todas">Todas</option>
+                        <option value="minhas">Minhas</option>
+                    </select>
+                </div>
+                <div class="cv-form-group" data-filter-context="solicitacoes" style="display:none;">
+                    <label for="solicitacao-status-filter">Situação:</label>
+                    <select id="solicitacao-status-filter" class="cv-input">
+                        <option value="">Todas</option>
+                        <option value="Aberto">Em Aberto</option>
+                        <option value="EmAndamento">Em Andamento</option>
+                        <option value="Concluido">Concluídas</option>
+                        <option value="Cancelado">Canceladas</option>
+                    </select>
+                </div>
+                <div class="cv-form-group" data-filter-context="ocorrencias" style="display:none;">
+                    <label for="ocorrencia-author-filter">Autor:</label>
+                    <select id="ocorrencia-author-filter" class="cv-input">
+                        <option value="todas">Todas</option>
+                        <option value="minhas">Minhas</option>
+                    </select>
+                </div>
+                <div class="cv-form-group" data-filter-context="ocorrencias" style="display:none;">
+                    <label for="ocorrencia-status-filter">Situação:</label>
+                    <select id="ocorrencia-status-filter" class="cv-input">
+                        <option value="">Todas</option>
+                        <option value="ABERTA">Em Aberto</option>
+                        <option value="EM_ATENDIMENTO">Em Atendimento</option>
+                        <option value="RESOLVIDA">Resolvidas</option>
+                        <option value="CANCELADA">Canceladas</option>
+                    </select>
+                </div>
                 <div class="cv-form-actions">
                     <button id="apply-filters-button-modal" class="cv-button primary">Aplicar Filtros</button>
                     <button type="button" class="cv-button js-modal-filtros-close">Cancelar</button>
+                </div>
+            </div>
+        </div>
+    </div>
+
+    <div id="modal-sort" class="cv-modal" style="display:none;">
+        <div class="cv-modal-content">
+            <span class="cv-modal-close js-modal-sort-close">&times;</span>
+            <h2>Ordenação</h2>
+            <div class="cv-form">
+                <div class="cv-form-group">
+                    <label for="sort-order-select">Ordenar por:</label>
+                    <select id="sort-order-select" class="cv-input">
+                        <option value="desc">Mais recentes</option>
+                        <option value="asc">Mais antigos</option>
+                    </select>
+                </div>
+                <div class="cv-form-actions">
+                    <button id="apply-sort-button" class="cv-button primary">Aplicar</button>
+                    <button type="button" class="cv-button js-modal-sort-close">Cancelar</button>
                 </div>
             </div>
         </div>

--- a/conViver.Web/wwwroot/css/styles.css
+++ b/conViver.Web/wwwroot/css/styles.css
@@ -790,9 +790,11 @@ main {
     margin-bottom: 20px;
     border-bottom: 2px solid var(--current-border-subtle, #eee); /* Use variable or fallback */
 }
-.cv-tabs > #open-filter-reservas-button,
-.cv-tabs > #open-filter-modal-button {
+.cv-tabs > #open-sort-button {
     margin-left: auto;
+}
+.cv-tabs > #open-filter-modal-button {
+    margin-left: 10px;
 }
 
 .cv-tab-button {

--- a/conViver.Web/wwwroot/pages/comunicacao.html
+++ b/conViver.Web/wwwroot/pages/comunicacao.html
@@ -5,6 +5,11 @@
                 <button class="cv-tab-button" id="tab-solicitacoes">Solicitações</button>
                 <button class="cv-tab-button" id="tab-ocorrencias">Ocorrências</button>
             </div>
+            <button id="open-sort-button" class="cv-button icon-button" title="Ordenar">
+                <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+                    <polyline points="6 9 12 15 18 9"></polyline>
+                </svg>
+            </button>
             <button id="open-filter-modal-button" class="cv-button icon-button" title="Filtros">
                 <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
                     <polygon points="22 3 2 3 10 12.46 10 19 14 21 14 12.46 22 3"></polygon>
@@ -30,7 +35,7 @@
                 <div class="cv-card feed-skeleton-item"><div class="skeleton-title"></div><div class="skeleton-line"></div><div class="skeleton-line short"></div></div>
             </div>
             <p class="cv-info-message" style="padding: 20px; text-align: center;">
-                As enquetes são exibidas no Mural principal.
+                Nenhuma enquete encontrada para os filtros atuais.
                 <span class="js-sindico-only-message" style="display:none;">Use o botão (+) para criar uma nova enquete.</span>
             </p>
         </div>
@@ -85,9 +90,79 @@
                     <label for="period-filter-modal">Período (Mês/Ano):</label>
                     <input type="month" id="period-filter-modal" name="period-filter-modal" class="cv-input">
                 </div>
+                <div class="cv-form-group" data-filter-context="enquetes" style="display:none;">
+                    <label for="enquete-author-filter">Autor:</label>
+                    <select id="enquete-author-filter" class="cv-input">
+                        <option value="todas">Todas</option>
+                        <option value="minhas">Minhas</option>
+                    </select>
+                </div>
+                <div class="cv-form-group" data-filter-context="enquetes" style="display:none;">
+                    <label for="enquete-status-filter">Situação:</label>
+                    <select id="enquete-status-filter" class="cv-input">
+                        <option value="">Todas</option>
+                        <option value="Aberta">Em Aberto</option>
+                        <option value="Concluida">Concluídas</option>
+                        <option value="Cancelada">Canceladas</option>
+                    </select>
+                </div>
+                <div class="cv-form-group" data-filter-context="solicitacoes" style="display:none;">
+                    <label for="solicitacao-author-filter">Autor:</label>
+                    <select id="solicitacao-author-filter" class="cv-input">
+                        <option value="todas">Todas</option>
+                        <option value="minhas">Minhas</option>
+                    </select>
+                </div>
+                <div class="cv-form-group" data-filter-context="solicitacoes" style="display:none;">
+                    <label for="solicitacao-status-filter">Situação:</label>
+                    <select id="solicitacao-status-filter" class="cv-input">
+                        <option value="">Todas</option>
+                        <option value="Aberto">Em Aberto</option>
+                        <option value="EmAndamento">Em Andamento</option>
+                        <option value="Concluido">Concluídas</option>
+                        <option value="Cancelado">Canceladas</option>
+                    </select>
+                </div>
+                <div class="cv-form-group" data-filter-context="ocorrencias" style="display:none;">
+                    <label for="ocorrencia-author-filter">Autor:</label>
+                    <select id="ocorrencia-author-filter" class="cv-input">
+                        <option value="todas">Todas</option>
+                        <option value="minhas">Minhas</option>
+                    </select>
+                </div>
+                <div class="cv-form-group" data-filter-context="ocorrencias" style="display:none;">
+                    <label for="ocorrencia-status-filter">Situação:</label>
+                    <select id="ocorrencia-status-filter" class="cv-input">
+                        <option value="">Todas</option>
+                        <option value="ABERTA">Em Aberto</option>
+                        <option value="EM_ATENDIMENTO">Em Atendimento</option>
+                        <option value="RESOLVIDA">Resolvidas</option>
+                        <option value="CANCELADA">Canceladas</option>
+                    </select>
+                </div>
                 <div class="cv-form-actions">
                     <button id="apply-filters-button-modal" class="cv-button primary">Aplicar Filtros</button>
                     <button type="button" class="cv-button js-modal-filtros-close">Cancelar</button>
+                </div>
+            </div>
+        </div>
+    </div>
+
+    <div id="modal-sort" class="cv-modal" style="display:none;">
+        <div class="cv-modal-content">
+            <span class="cv-modal-close js-modal-sort-close">&times;</span>
+            <h2>Ordenação</h2>
+            <div class="cv-form">
+                <div class="cv-form-group">
+                    <label for="sort-order-select">Ordenar por:</label>
+                    <select id="sort-order-select" class="cv-input">
+                        <option value="desc">Mais recentes</option>
+                        <option value="asc">Mais antigos</option>
+                    </select>
+                </div>
+                <div class="cv-form-actions">
+                    <button id="apply-sort-button" class="cv-button primary">Aplicar</button>
+                    <button type="button" class="cv-button js-modal-sort-close">Cancelar</button>
                 </div>
             </div>
         </div>


### PR DESCRIPTION
## Summary
- include `CriadoPor` in feed items and expose in APIs
- support additional feed filters (author and status)
- update voting service mappings
- add sort button and contextual filter groups on communication page
- implement sort modal and client-side ordering

## Testing
- `dotnet test` *(failed: `dotnet` not found)*

------
https://chatgpt.com/codex/tasks/task_e_685f1685d0e08332840707e7c21f6952