### PR TITLE
Fix Ocorrência role checks

### DIFF
--- a/conViver.Web/js/comunicacao.js
+++ b/conViver.Web/js/comunicacao.js
@@ -740,6 +740,11 @@ async function handleDeleteAviso(itemId) {
   }
 }
 
+// Returns the raw roles saved in localStorage by the authentication flow.
+// Residents may appear as "Condomino" or "Inquilino" but the Ocorrências
+// endpoints expect the more generic role "Morador". Permission checks that
+// rely on that role should treat "Condomino" and "Inquilino" as synonyms of
+// "Morador".
 function getUserRoles() {
   const user = JSON.parse(localStorage.getItem("userInfo"));
   if (user && user.roles) return user.roles;

--- a/conViver.Web/js/ocorrencias.js
+++ b/conViver.Web/js/ocorrencias.js
@@ -175,6 +175,12 @@ async function initOcorrenciasPage() {
          tabTodasOcorrencias.style.display = 'none';
     }
 
+    const normalizedRoles = normalizeRoles(currentUser.roles || []);
+    const canCreate = ['Morador','Sindico','Administrador'].some(r => normalizedRoles.includes(r));
+    if (!canCreate && btnNovaOcorrencia) {
+        btnNovaOcorrencia.style.display = 'none';
+    }
+
 
     await loadCategorias();
     await loadOcorrencias(currentPage, currentFilter);
@@ -361,6 +367,10 @@ function handleTabClick(event) {
 }
 
 function openNovaOcorrenciaModal() {
+    if (!canCreateOcorrencia()) {
+        showGlobalFeedback('Apenas moradores, s\u00edndicos ou administradores podem abrir ocorr\u00eancias.', 'error');
+        return;
+    }
     formNovaOcorrencia.reset();
     anexosPreviewContainer.innerHTML = '';
     displayFormErrors(formNovaOcorrenciaErrorsEl, []); // Clear previous errors
@@ -756,6 +766,17 @@ function canUserAddAttachment(ocorrencia) {
     return ocorrencia.usuario?.id === currentUser.id ||
            currentUser.roles.includes('Sindico') ||
            currentUser.roles.includes('Administrador');
+}
+
+// Normalize roles so that "Condomino" and "Inquilino" are treated as "Morador".
+function normalizeRoles(roles) {
+    return roles.map(r => (r === 'Condomino' || r === 'Inquilino') ? 'Morador' : r);
+}
+
+function canCreateOcorrencia() {
+    if (!currentUser || !Array.isArray(currentUser.roles)) return false;
+    const normalized = normalizeRoles(currentUser.roles);
+    return normalized.includes('Morador') || normalized.includes('Sindico') || normalized.includes('Administrador');
 }
 
 

--- a/conViver.Web/wwwroot/js/comunicacao.js
+++ b/conViver.Web/wwwroot/js/comunicacao.js
@@ -740,6 +740,11 @@ async function handleDeleteAviso(itemId) {
   }
 }
 
+// Returns the raw roles saved in localStorage by the authentication flow.
+// Residents may appear as "Condomino" or "Inquilino" but the Ocorrências
+// endpoints expect the more generic role "Morador". Permission checks that
+// rely on that role should treat "Condomino" and "Inquilino" as synonyms of
+// "Morador".
 function getUserRoles() {
   const user = JSON.parse(localStorage.getItem("userInfo"));
   if (user && user.roles) return user.roles;

--- a/conViver.Web/wwwroot/js/ocorrencias.js
+++ b/conViver.Web/wwwroot/js/ocorrencias.js
@@ -175,6 +175,12 @@ async function initOcorrenciasPage() {
          tabTodasOcorrencias.style.display = 'none';
     }
 
+    const normalizedRoles = normalizeRoles(currentUser.roles || []);
+    const canCreate = ['Morador','Sindico','Administrador'].some(r => normalizedRoles.includes(r));
+    if (!canCreate && btnNovaOcorrencia) {
+        btnNovaOcorrencia.style.display = 'none';
+    }
+
 
     await loadCategorias();
     await loadOcorrencias(currentPage, currentFilter);
@@ -361,6 +367,10 @@ function handleTabClick(event) {
 }
 
 function openNovaOcorrenciaModal() {
+    if (!canCreateOcorrencia()) {
+        showGlobalFeedback('Apenas moradores, s\u00edndicos ou administradores podem abrir ocorr\u00eancias.', 'error');
+        return;
+    }
     formNovaOcorrencia.reset();
     anexosPreviewContainer.innerHTML = '';
     displayFormErrors(formNovaOcorrenciaErrorsEl, []); // Clear previous errors
@@ -756,6 +766,16 @@ function canUserAddAttachment(ocorrencia) {
     return ocorrencia.usuario?.id === currentUser.id ||
            currentUser.roles.includes('Sindico') ||
            currentUser.roles.includes('Administrador');
+}
+
+function normalizeRoles(roles) {
+    return roles.map(r => (r === 'Condomino' || r === 'Inquilino') ? 'Morador' : r);
+}
+
+function canCreateOcorrencia() {
+    if (!currentUser || !Array.isArray(currentUser.roles)) return false;
+    const normalized = normalizeRoles(currentUser.roles);
+    return normalized.includes('Morador') || normalized.includes('Sindico') || normalized.includes('Administrador');
 }
 
 


### PR DESCRIPTION
## Summary
- clarify user role mapping in `comunicacao.js`
- hide "Nova Ocorrência" button unless user has Morador/Sindico/Administrador permissions
- prevent opening Ocorrência modal without proper role
- expose helper functions for normalizing roles

## Testing
- `dotnet test src/conViver.Tests/conViver.Tests.csproj --configuration Release --no-build` *(fails: `dotnet` not found)*

------
https://chatgpt.com/codex/tasks/task_e_685f220d0fc483329e833a5f847588ba