### PR TITLE
Fix condominio claim name in JWT

### DIFF
--- a/conViver.API/Controllers/UsuariosController.cs
+++ b/conViver.API/Controllers/UsuariosController.cs
@@ -113,7 +113,7 @@ public class UsuariosController : ControllerBase // Renomear para AuthController
 
         // Simulação de dados para o token (o JwtService deveria lidar com isso de forma mais robusta)
         // O JwtService.GenerateToken idealmente retornaria claims adicionais, mas o serviço atual aceita apenas o condominioId opcional
-        var accessTokenString = _jwt.GenerateToken(usuario.Id, usuario.Perfil.ToString(), null);
+        var accessTokenString = _jwt.GenerateToken(usuario.Id, usuario.Perfil.ToString(), usuario.CondominioId);
 
         // Placeholder para Refresh Token e Expiration - JwtService deveria fornecer isso
         var refreshTokenString = "dummyRefreshToken_jwtService_needs_to_implement_this_" + Guid.NewGuid().ToString();

--- a/conViver.Infrastructure/Authentication/JwtService.cs
+++ b/conViver.Infrastructure/Authentication/JwtService.cs
@@ -24,7 +24,7 @@ public class JwtService
 
         if (condominioId.HasValue)
         {
-            claims.Add(new Claim("condoId", condominioId.Value.ToString()));
+            claims.Add(new Claim("condominioId", condominioId.Value.ToString()));
         }
 
         var key = new SymmetricSecurityKey(Encoding.UTF8.GetBytes(_config.JwtSecret));

--- a/conViver.Web/js/auth.js
+++ b/conViver.Web/js/auth.js
@@ -36,7 +36,7 @@ export function getUserInfo() {
             email: payload.email || null,
             name: payload.given_name || payload.name || null,
             roles,
-            condominioId: payload.condoId || payload.condominioId || null,
+            condominioId: payload.condominioId || null,
         };
     } catch (err) {
         console.error('Failed to parse user token', err);

--- a/conViver.Web/wwwroot/js/auth.js
+++ b/conViver.Web/wwwroot/js/auth.js
@@ -36,7 +36,7 @@ export function getUserInfo() {
             email: payload.email || null,
             name: payload.given_name || payload.name || null,
             roles,
-            condominioId: payload.condoId || payload.condominioId || null,
+            condominioId: payload.condominioId || null,
         };
     } catch (err) {
         console.error('Failed to parse user token', err);


### PR DESCRIPTION
## Summary
- emit claim `condominioId` from `JwtService.GenerateToken`
- include the user`s condo id when generating the token in `UsuariosController.Login`
- parse `condominioId` from the token in web auth helpers

## Testing
- `dotnet test conViver.Tests/conViver.Tests.csproj --no-build --configuration Release` *(fails: `dotnet` not found)*

------
https://chatgpt.com/codex/tasks/task_e_685f2b8e2e94833299a13dc4d5a2c354