### PR TITLE
Implement ETag middleware for GET endpoints

### DIFF
--- a/API_REFERENCE.md
+++ b/API_REFERENCE.md
@@ -1,7 +1,13 @@
 ﻿# API Reference – conViver
 
-> Prefixo de rota: `/api/v1`  
+> Prefixo de rota: `/api/v1`
 > Todos os endpoints REST usam JSON e exigem header `Authorization: Bearer <token>` (exceto rotas públicas de auth).
+
+### Cache HTTP
+
+Alguns endpoints de leitura enviam cabeçalho `ETag`. Se o cliente reenviar
+`If-None-Match` com o valor fornecido e nada mudou, a API responde `304 Not Modified`.
+Isso reduz o tráfego e acelera apps que armazenam a última resposta.
 
 ---
 
@@ -1000,6 +1006,7 @@ Endpoints gerenciados por `AvisosController.cs`. Rotas base: `/api/v1/app/avisos
 *   `size` (int, default 10): Quantidade de itens por página.
 *   (`categoria` - mencionada no doc antigo, mas não no controller `ListarAvisosPorApp`. Pode ser adicionada).
 **Response 200** (`IEnumerable<Aviso>`) - Lista de entidades `Aviso` (verificar se DTO).
+**Response 304**: Enviado quando o cliente fornece `If-None-Match` com `ETag` válido.
 **Erros Comuns**:
 *   `401 Unauthorized`: CondominioId inválido.
 

--- a/conViver.API/Middleware/CachingMiddleware.cs
+++ b/conViver.API/Middleware/CachingMiddleware.cs
@@ -1,0 +1,60 @@
+using System.Security.Cryptography;
+using System.Text;
+using conViver.Infrastructure.Cache;
+
+namespace conViver.API.Middleware;
+
+public class CachingMiddleware
+{
+    private readonly RequestDelegate _next;
+    private readonly ILogger<CachingMiddleware> _logger;
+    private readonly RedisCacheService _cache;
+
+    public CachingMiddleware(RequestDelegate next, ILogger<CachingMiddleware> logger, RedisCacheService cache)
+    {
+        _next = next;
+        _logger = logger;
+        _cache = cache;
+    }
+
+    public async Task Invoke(HttpContext context)
+    {
+        if (!HttpMethods.IsGet(context.Request.Method))
+        {
+            await _next(context);
+            return;
+        }
+
+        var cacheKey = $"etag:{context.Request.Path}{context.Request.QueryString}";
+        var storedEtag = await _cache.GetAsync(cacheKey);
+
+        if (storedEtag != null && context.Request.Headers.TryGetValue("If-None-Match", out var requestEtag) && requestEtag == storedEtag)
+        {
+            context.Response.StatusCode = StatusCodes.Status304NotModified;
+            return;
+        }
+
+        var originalBody = context.Response.Body;
+        await using var memStream = new MemoryStream();
+        context.Response.Body = memStream;
+
+        await _next(context);
+
+        memStream.Seek(0, SeekOrigin.Begin);
+        var bodyText = await new StreamReader(memStream).ReadToEndAsync();
+        var eTag = GenerateETag(bodyText);
+        context.Response.Headers["ETag"] = eTag;
+        await _cache.SetAsync(cacheKey, eTag, TimeSpan.FromMinutes(5));
+
+        memStream.Seek(0, SeekOrigin.Begin);
+        await memStream.CopyToAsync(originalBody);
+        context.Response.Body = originalBody;
+    }
+
+    private static string GenerateETag(string input)
+    {
+        using var sha = SHA256.Create();
+        var bytes = sha.ComputeHash(Encoding.UTF8.GetBytes(input));
+        return Convert.ToBase64String(bytes);
+    }
+}

--- a/conViver.API/Program.cs
+++ b/conViver.API/Program.cs
@@ -111,6 +111,7 @@ app.UsePathBase("/api/v1");
 
 app.UseMiddleware<RequestLoggingMiddleware>();
 app.UseMiddleware<ExceptionMiddleware>();
+app.UseMiddleware<CachingMiddleware>();
 
 // Enable CORS
 app.UseCors(AllowDevOrigins);


### PR DESCRIPTION
## Summary
- add new `CachingMiddleware` using `RedisCacheService`
- enable middleware in `Program.cs`
- document cache behaviour and 304 responses

## Testing
- `dotnet build --no-restore`

------
https://chatgpt.com/codex/tasks/task_e_685f5ac00234833291e2a9340f8e2644