### PR TITLE
Implement optimistic deletion feedback

### DIFF
--- a/README.md
+++ b/README.md
@@ -215,6 +215,7 @@ O cliente web (`conViver.Web`) utiliza um sistema de feedback visual global para
 - Mensagens de sucesso ou erro são exibidas em um banner (`<div id="global-message-banner">`).
 - Esta funcionalidade é gerenciada automaticamente por `js/apiClient.js`.
 - Para mostrar ou ocultar placeholders de carregamento (skeletons), utilize `showSkeleton()` e `hideSkeleton()` de `js/main.js` nos módulos.
+- Operações de exclusão utilizam **comportamento otimista**: o item é escondido assim que o usuário confirma e a requisição `apiClient.delete` é enviada. Se a remoção falhar (HTTP >= 400), o elemento volta a aparecer e um feedback de erro é exibido.
 
 ### Estrutura de Páginas & Navegação
 As páginas HTML da aplicação web ficam em `conViver.Web/pages`. Crie novos arquivos nesse diretório para adicionar funcionalidades.

--- a/conViver.Web/js/biblioteca.js
+++ b/conViver.Web/js/biblioteca.js
@@ -96,6 +96,7 @@ async function loadDocumentos() {
     documentos.forEach(doc => {
         const docElement = document.createElement('div');
         docElement.className = 'cv-card document-item';
+        docElement.dataset.docId = doc.id;
         // Usar doc.url diretamente se for a URL de download, ou construir com base no ID
         // A rota de download é /api/v1/docs/download/{id}
         const downloadUrl = `${apiClient.getBaseUrl()}/docs/download/${doc.id}`;
@@ -122,8 +123,9 @@ async function loadDocumentos() {
         document.querySelectorAll('.js-delete-doc').forEach(button => {
             button.addEventListener('click', async (event) => {
                 const docId = event.target.dataset.docId;
+                const card = event.target.closest('.document-item');
                 if (confirm(`Tem certeza que deseja excluir o documento ID: ${docId}?`)) {
-                    await handleDeleteDocumento(docId);
+                    await handleDeleteDocumento(docId, card);
                 }
             });
         });
@@ -166,16 +168,16 @@ async function handleUploadDocumento(event) {
     }
 }
 
-async function handleDeleteDocumento(docId) {
+async function handleDeleteDocumento(docId, card) {
+    if (card) card.style.display = 'none';
     try {
-        // O endpoint é /api/v1/syndic/docs/{id}
         await apiClient.delete(`/api/v1/syndic/docs/${docId}`);
-        loadDocumentos(); // Recarrega a lista
+        if (card) card.remove();
+        else loadDocumentos();
     } catch (error) {
         console.error(`Erro ao excluir documento ${docId}:`, error);
-         if (!error.handledByApiClient) {
-            showGlobalFeedback(error.message || 'Falha ao excluir documento.', 'error');
-        }
+        if (card) card.style.display = '';
+        showGlobalFeedback('Falha ao remover documento.', 'error');
     }
 }
 

--- a/conViver.Web/js/comunicacao.js
+++ b/conViver.Web/js/comunicacao.js
@@ -781,26 +781,24 @@ function setupFeedItemActionButtons() {
 }
 
 async function handleDeleteAviso(itemId) {
-  showGlobalFeedback("Excluindo aviso...", "info");
+  const card = document.querySelector(
+    `${feedContainerSelector} .cv-card[data-item-id="${itemId}"][data-item-type="Aviso"]`
+  );
+  if (card) card.style.display = "none";
   try {
     await apiClient.delete(`/api/v1/avisos/syndic/avisos/${itemId}`);
     showGlobalFeedback("Aviso excluído com sucesso!", "success");
     fetchedFeedItems = fetchedFeedItems.filter(
       (i) => !(i.id.toString() === itemId.toString() && i.itemType === "Aviso")
     );
-    const cardToRemove = document.querySelector(
-      `${feedContainerSelector} .cv-card[data-item-id="${itemId}"][data-item-type="Aviso"]`
-    );
-    if (cardToRemove) {
-      cardToRemove.remove();
-    } else {
+    if (card) card.remove();
+    else {
       await loadInitialFeedItems();
     }
   } catch (error) {
     console.error("Erro ao excluir aviso:", error);
-    if (!error.handledByApiClient) {
-      showGlobalFeedback(error.message || "Falha ao excluir o aviso.", "error");
-    }
+    if (card) card.style.display = "";
+    showGlobalFeedback("Falha ao remover aviso.", "error");
   }
 }
 

--- a/conViver.Web/js/ocorrencias.js
+++ b/conViver.Web/js/ocorrencias.js
@@ -724,17 +724,20 @@ async function handleDeleteOcorrencia() {
     if (!confirm('Tem certeza que deseja excluir esta ocorrência? Esta ação não pode ser desfeita.')) {
         return;
     }
+    const card = document.querySelector(`.ocorrencia-card[data-ocorrencia-id="${currentOcorrenciaId}"]`);
+    if (card) card.style.display = 'none';
     isLoading = true;
 
     try {
         await apiClient.delete(`/api/ocorrencias/${currentOcorrenciaId}`);
+        if (card) card.remove();
         closeDetalheOcorrenciaModal();
         await loadOcorrencias(1, currentFilter); // Refresh list, go to first page
         showGlobalFeedback('Ocorrência excluída com sucesso!', 'success', 4000);
     } catch (error) {
         console.error('Erro ao excluir ocorrência:', error);
-        showGlobalFeedback(`Erro ao excluir ocorrência: ${error.message}`, 'error', 6000);
-        // Potentially show error in modal if it's still relevant or a global message
+        if (card) card.style.display = '';
+        showGlobalFeedback('Falha ao remover ocorrência.', 'error');
     } finally {
         isLoading = false;
     }

--- a/conViver.Web/wwwroot/js/biblioteca.js
+++ b/conViver.Web/wwwroot/js/biblioteca.js
@@ -96,6 +96,7 @@ async function loadDocumentos() {
     documentos.forEach(doc => {
         const docElement = document.createElement('div');
         docElement.className = 'cv-card document-item';
+        docElement.dataset.docId = doc.id;
         // Usar doc.url diretamente se for a URL de download, ou construir com base no ID
         // A rota de download é /api/v1/docs/download/{id}
         const downloadUrl = `${apiClient.getBaseUrl()}/docs/download/${doc.id}`;
@@ -122,8 +123,9 @@ async function loadDocumentos() {
         document.querySelectorAll('.js-delete-doc').forEach(button => {
             button.addEventListener('click', async (event) => {
                 const docId = event.target.dataset.docId;
+                const card = event.target.closest('.document-item');
                 if (confirm(`Tem certeza que deseja excluir o documento ID: ${docId}?`)) {
-                    await handleDeleteDocumento(docId);
+                    await handleDeleteDocumento(docId, card);
                 }
             });
         });
@@ -166,16 +168,16 @@ async function handleUploadDocumento(event) {
     }
 }
 
-async function handleDeleteDocumento(docId) {
+async function handleDeleteDocumento(docId, card) {
+    if (card) card.style.display = 'none';
     try {
-        // O endpoint é /api/v1/syndic/docs/{id}
         await apiClient.delete(`/api/v1/syndic/docs/${docId}`);
-        loadDocumentos(); // Recarrega a lista
+        if (card) card.remove();
+        else loadDocumentos();
     } catch (error) {
         console.error(`Erro ao excluir documento ${docId}:`, error);
-         if (!error.handledByApiClient) {
-            showGlobalFeedback(error.message || 'Falha ao excluir documento.', 'error');
-        }
+        if (card) card.style.display = '';
+        showGlobalFeedback('Falha ao remover documento.', 'error');
     }
 }
 

--- a/conViver.Web/wwwroot/js/comunicacao.js
+++ b/conViver.Web/wwwroot/js/comunicacao.js
@@ -781,26 +781,24 @@ function setupFeedItemActionButtons() {
 }
 
 async function handleDeleteAviso(itemId) {
-  showGlobalFeedback("Excluindo aviso...", "info");
+  const card = document.querySelector(
+    `${feedContainerSelector} .cv-card[data-item-id="${itemId}"][data-item-type="Aviso"]`
+  );
+  if (card) card.style.display = "none";
   try {
     await apiClient.delete(`/api/v1/avisos/syndic/avisos/${itemId}`);
     showGlobalFeedback("Aviso excluído com sucesso!", "success");
     fetchedFeedItems = fetchedFeedItems.filter(
       (i) => !(i.id.toString() === itemId.toString() && i.itemType === "Aviso")
     );
-    const cardToRemove = document.querySelector(
-      `${feedContainerSelector} .cv-card[data-item-id="${itemId}"][data-item-type="Aviso"]`
-    );
-    if (cardToRemove) {
-      cardToRemove.remove();
-    } else {
+    if (card) card.remove();
+    else {
       await loadInitialFeedItems();
     }
   } catch (error) {
     console.error("Erro ao excluir aviso:", error);
-    if (!error.handledByApiClient) {
-      showGlobalFeedback(error.message || "Falha ao excluir o aviso.", "error");
-    }
+    if (card) card.style.display = "";
+    showGlobalFeedback("Falha ao remover aviso.", "error");
   }
 }
 

--- a/conViver.Web/wwwroot/js/ocorrencias.js
+++ b/conViver.Web/wwwroot/js/ocorrencias.js
@@ -724,17 +724,20 @@ async function handleDeleteOcorrencia() {
     if (!confirm('Tem certeza que deseja excluir esta ocorrência? Esta ação não pode ser desfeita.')) {
         return;
     }
+    const card = document.querySelector(`.ocorrencia-card[data-ocorrencia-id="${currentOcorrenciaId}"]`);
+    if (card) card.style.display = 'none';
     isLoading = true;
 
     try {
         await apiClient.delete(`/api/ocorrencias/${currentOcorrenciaId}`);
+        if (card) card.remove();
         closeDetalheOcorrenciaModal();
         await loadOcorrencias(1, currentFilter); // Refresh list, go to first page
         showGlobalFeedback('Ocorrência excluída com sucesso!', 'success', 4000);
     } catch (error) {
         console.error('Erro ao excluir ocorrência:', error);
-        showGlobalFeedback(`Erro ao excluir ocorrência: ${error.message}`, 'error', 6000);
-        // Potentially show error in modal if it's still relevant or a global message
+        if (card) card.style.display = '';
+        showGlobalFeedback('Falha ao remover ocorrência.', 'error');
     } finally {
         isLoading = false;
     }


### PR DESCRIPTION
## Summary
- optimistically hide cards before `delete` calls across modules
- restore item and show error feedback if deletion fails
- document optimistic behavior for the web client

## Testing
- `dotnet test conViver.Tests/conViver.Tests.csproj --configuration Release`

------
https://chatgpt.com/codex/tasks/task_e_685f5ad2d1288332a6cfd002d9ac149f