### PR TITLE
Add inline spinner support for PUT actions

### DIFF
--- a/conViver.Web/css/components.css
+++ b/conViver.Web/css/components.css
@@ -656,3 +656,21 @@ html[data-theme="dark"] {
     color: var(--current-semantic-error);
 }
 /* === End Status Badge Utility Classes === */
+
+/* Inline spinner utility */
+.inline-spinner {
+    display: inline-block;
+    width: 1em;
+    height: 1em;
+    border: 2px solid currentColor;
+    border-right-color: transparent;
+    border-radius: 50%;
+    animation: cv-inline-spin 0.75s linear infinite;
+    margin-left: 4px;
+    vertical-align: middle;
+}
+
+@keyframes cv-inline-spin {
+    from { transform: rotate(0deg); }
+    to { transform: rotate(360deg); }
+}

--- a/conViver.Web/js/comunicacao.js
+++ b/conViver.Web/js/comunicacao.js
@@ -1,6 +1,6 @@
 import apiClient from "./apiClient.js";
 import { requireAuth } from "./auth.js";
-import { showGlobalFeedback, showSkeleton, hideSkeleton } from "./main.js";
+import { showGlobalFeedback, showSkeleton, hideSkeleton, showInlineSpinner } from "./main.js";
 import { initFabMenu } from "./fabMenu.js";
 
 // --- Global state & constants ---
@@ -494,6 +494,8 @@ function setupModalEventListeners() {
     if (formCriarAviso && avisoIdField) {
       formCriarAviso.addEventListener("submit", async (event) => {
         event.preventDefault();
+        const submitBtn = formCriarAviso.querySelector('button[type="submit"]');
+        const hideSpinner = showInlineSpinner(submitBtn);
         const currentAvisoId = avisoIdField.value;
         const formData = new FormData(formCriarAviso);
 
@@ -546,6 +548,8 @@ function setupModalEventListeners() {
               "error"
             );
           }
+        } finally {
+          hideSpinner();
         }
       });
     }
@@ -755,7 +759,9 @@ function setupFeedItemActionButtons() {
         if (
           confirm("Tem certeza que deseja encerrar esta enquete manualmente?")
         ) {
+          const hideSpinner = showInlineSpinner(event.target);
           await handleEndEnquete(itemId);
+          hideSpinner();
         }
       });
     } else {
@@ -1262,7 +1268,9 @@ async function handleFeedItemClick(event) {
   }
   if (clickedElement.classList.contains("js-end-enquete-item")) {
     if (confirm("Tem certeza que deseja encerrar esta enquete manualmente?")) {
+      const hideSpinner = showInlineSpinner(clickedElement);
       await handleEndEnquete(itemId);
+      hideSpinner();
     }
     return;
   }
@@ -1633,6 +1641,8 @@ async function submitChamadoUpdateBySindico(chamadoId) {
   const respostaTextarea = document.getElementById(
     "modal-chamado-resposta-textarea"
   );
+  const updateBtn = document.getElementById("modal-chamado-submit-sindico-update");
+  const hideSpinner = showInlineSpinner(updateBtn);
 
   if (!statusSelect || !respostaTextarea) {
     showGlobalFeedback(
@@ -1667,6 +1677,8 @@ async function submitChamadoUpdateBySindico(chamadoId) {
         "error"
       );
     }
+  } finally {
+    hideSpinner();
   }
 }
 

--- a/conViver.Web/js/financeiro.js
+++ b/conViver.Web/js/financeiro.js
@@ -1,6 +1,6 @@
 import apiClient, { ApiError } from './apiClient.js';
 import { requireAuth } from './auth.js';
-import { formatCurrency, formatDate, showGlobalFeedback } from './main.js';
+import { formatCurrency, formatDate, showGlobalFeedback, showInlineSpinner } from './main.js';
 import { showFeedSkeleton, hideFeedSkeleton } from './skeleton.js';
 
 function getStatusBadgeHtml(status) {
@@ -259,6 +259,7 @@ document.addEventListener('DOMContentLoaded', () => {
             } else if (target.classList.contains('js-btn-cancelar-cobranca')) {
                 if (!confirm('Tem certeza que deseja cancelar esta cobrança?')) return;
                 target.disabled = true;
+                const hideSpinner = showInlineSpinner(target);
                 try {
                     const resultado = await apiClient.put(`/financeiro/cobrancas/${cobrancaId}/cancelar`, {});
                     if (resultado && resultado.sucesso) {
@@ -277,6 +278,7 @@ document.addEventListener('DOMContentLoaded', () => {
                     }
                 } finally {
                     target.disabled = false;
+                    hideSpinner();
                 }
             }
         });

--- a/conViver.Web/js/main.js
+++ b/conViver.Web/js/main.js
@@ -177,6 +177,25 @@ export function hideSkeleton(target) {
     });
 }
 
+/**
+ * Mostra um pequeno spinner dentro do elemento fornecido e retorna
+ * uma função que remove o spinner.
+ * @param {HTMLElement} element Elemento onde o spinner será exibido.
+ * @returns {Function} Função para remover o spinner criado.
+ */
+export function showInlineSpinner(element) {
+    if (!element) return () => {};
+
+    const spinner = document.createElement('span');
+    spinner.className = 'inline-spinner';
+    spinner.setAttribute('aria-hidden', 'true');
+    element.appendChild(spinner);
+
+    return () => {
+        if (spinner.parentElement) spinner.remove();
+    };
+}
+
 
 // Exemplo de como poderia ser usado para inicializações (se necessário no futuro):
 // document.addEventListener('DOMContentLoaded', () => {


### PR DESCRIPTION
## Summary
- create `showInlineSpinner` utility
- add CSS for inline spinner
- display spinner when cancelling cobrança, submitting avisos, ending enquetes and updating chamados
- hide spinner when requests finish

## Testing
- `dotnet test conViver.Tests/conViver.Tests.csproj --configuration Release`

------
https://chatgpt.com/codex/tasks/task_e_685f5ad013ec8332a011bd903fc2310c