### PR TITLE
Improve Redis handling in dev setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,6 +120,12 @@ dotnet run
 set ASPNETCORE_ENVIRONMENT=Development
 dotnet run
 
+# Certifique-se de que o Redis esteja rodando
+# (ex.: `docker compose up` ou `redis-server`).
+# A conexão padrão em `appsettings.Development.json` usa
+# `localhost:6379,abortConnect=false` para evitar falhas caso o
+# serviço ainda não esteja disponível.
+
 # /auth/signup é um POST – veja API_REFERENCE.md atualizado para DTOs corretos.
 
 4. Front Web

--- a/conViver.API/appsettings.Development.json
+++ b/conViver.API/appsettings.Development.json
@@ -1,5 +1,5 @@
 {
   "DB_CONNECTION": "Data Source=conviver.db",
   "JWT_SECRET": "AStrongRandomSecretForJwtTokenAuth12345",
-  "REDIS_CONNECTION": "localhost:6379"
+  "REDIS_CONNECTION": "localhost:6379,abortConnect=false"
 }


### PR DESCRIPTION
## Summary
- append `abortConnect=false` in Development Redis connection string
- explain requirement to run Redis in README

## Testing
- `dotnet build conViver.sln`
- `dotnet test conViver.Tests/conViver.Tests.csproj`

------
https://chatgpt.com/codex/tasks/task_e_685f5e394fe08332bd9a96028feec193