### PR TITLE
Add offline NuGet cache script

### DIFF
--- a/TEST_GUIDE.md
+++ b/TEST_GUIDE.md
@@ -20,15 +20,18 @@ A solução utiliza um projeto de teste principal: `conViver.Tests`. Dentro dest
 
 ## 2. Preparando o Ambiente
 
-1. **.NET SDK 8.0** instalado e no `PATH`.  
-2. Variáveis de ambiente (pode usar `dotnet user-secrets` ou `.env`):  
+1. **.NET SDK 8.0** instalado e no `PATH`.
+2. Variáveis de ambiente (pode usar `dotnet user-secrets` ou `.env`):
    ```bash
    export DB_CONNECTION="Host=localhost;Port=5432;Username=postgres;Password=devpass;Database=conviver_test;"
    export REDIS_CONNECTION="localhost:6379"
    export JWT_SECRET="test-secret-32chars"
 
 
-Docker rodando para testes de integração com Testcontainers (se utilizados).
+3. Docker rodando para testes de integração com Testcontainers (se utilizados).
+4. Conexão com a **Internet** para restaurar os pacotes NuGet na primeira execução.
+   Caso precise executar offline, rode `scripts/populate_offline_packages.sh` previamente
+   em uma máquina conectada para gerar o cache em `./.nuget`.
 
 ## 3. Executando Testes Localmente
 

--- a/scripts/populate_offline_packages.sh
+++ b/scripts/populate_offline_packages.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+# Populate local NuGet cache for offline builds
+set -euo pipefail
+
+# Directory for local packages
+CACHE_DIR="$(pwd)/.nuget/packages"
+mkdir -p "$CACHE_DIR"
+
+# Restore packages to local cache
+NUGET_PACKAGES="$CACHE_DIR" dotnet restore conViver.sln
+
+echo "Packages restored to $CACHE_DIR"


### PR DESCRIPTION
## Summary
- document that restoring NuGet packages requires Internet access
- add script to populate a local NuGet cache for offline builds

## Testing
- `dotnet --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685f68dba61083329dec8cda29b0acbf