### PR TITLE
Add in-memory cache option

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,6 +125,8 @@ dotnet run
 # A conexão padrão em `appsettings.Development.json` usa
 # `localhost:6379,abortConnect=false` para evitar falhas caso o
 # serviço ainda não esteja disponível.
+# Você pode definir `USE_REDIS=false` para usar um cache em memória
+# e dispensar o serviço do Redis durante o desenvolvimento.
 
 # /auth/signup é um POST – veja API_REFERENCE.md atualizado para DTOs corretos.
 
@@ -145,6 +147,7 @@ dotnet build -t:Run -f net8.0-android
 | `DB_CONNECTION`               | String de conexão para PostgreSQL ou SQLite.                                                                                            | `Host=localhost;Database=conviver;Username=user;Password=pass` ou `Data Source=conviver.db` |
 | `JWT_SECRET`                  | Chave secreta para assinatura de tokens JWT (HMAC-SHA256). Mínimo 32 caracteres.                                                        | `uma-chave-secreta-muito-longa-e-segura-aqui`             |
 | `REDIS_CONNECTION`            | String de conexão para o Redis.                                                                                                         | `localhost:6379,abortConnect=false`                       |
+| `USE_REDIS`                   | Quando `true`, a API usa Redis para cache HTTP. Defina `false` para cache em memória. | `true` |
 | `BASE_URL`                    | URL base pública da API, usada em contextos como geração de links em emails.                                                            | `https://sua-api.com/api/v1`                              |
 | `API_CORS_ALLOWED_ORIGINS`    | Define as origens permitidas para CORS na API. Valor em `conViver.API/appsettings.json` (ex: `CorsSettings:AllowedOrigins`).            | `http://localhost:3000;https://yourdomain.com`            |
 | `WEB_API_BASE_URL`            | Define a URL base da API para o cliente web. Valor em `conViver.Web/js/config.js` (ex: `window.APP_CONFIG.API_BASE_URL`).                | `http://localhost:5000/api/v1`                            |

--- a/conViver.API/Middleware/CachingMiddleware.cs
+++ b/conViver.API/Middleware/CachingMiddleware.cs
@@ -8,9 +8,9 @@ public class CachingMiddleware
 {
     private readonly RequestDelegate _next;
     private readonly ILogger<CachingMiddleware> _logger;
-    private readonly RedisCacheService _cache;
+    private readonly ICacheService _cache;
 
-    public CachingMiddleware(RequestDelegate next, ILogger<CachingMiddleware> logger, RedisCacheService cache)
+    public CachingMiddleware(RequestDelegate next, ILogger<CachingMiddleware> logger, ICacheService cache)
     {
         _next = next;
         _logger = logger;

--- a/conViver.API/appsettings.Development.json
+++ b/conViver.API/appsettings.Development.json
@@ -1,5 +1,6 @@
 {
   "DB_CONNECTION": "Data Source=conviver.db",
   "JWT_SECRET": "AStrongRandomSecretForJwtTokenAuth12345",
-  "REDIS_CONNECTION": "localhost:6379,abortConnect=false"
+  "REDIS_CONNECTION": "localhost:6379,abortConnect=false",
+  "USE_REDIS": false
 }

--- a/conViver.Infrastructure/Cache/ICacheService.cs
+++ b/conViver.Infrastructure/Cache/ICacheService.cs
@@ -1,0 +1,7 @@
+namespace conViver.Infrastructure.Cache;
+
+public interface ICacheService
+{
+    Task SetAsync(string key, string value, TimeSpan? expiry = null);
+    Task<string?> GetAsync(string key);
+}

--- a/conViver.Infrastructure/Cache/InMemoryCacheService.cs
+++ b/conViver.Infrastructure/Cache/InMemoryCacheService.cs
@@ -1,0 +1,31 @@
+using System.Collections.Concurrent;
+
+namespace conViver.Infrastructure.Cache;
+
+public class InMemoryCacheService : ICacheService
+{
+    private readonly ConcurrentDictionary<string, CacheEntry> _cache = new();
+
+    public Task SetAsync(string key, string value, TimeSpan? expiry = null)
+    {
+        var expiresAt = expiry.HasValue ? DateTimeOffset.UtcNow.Add(expiry.Value) : (DateTimeOffset?)null;
+        _cache[key] = new CacheEntry(value, expiresAt);
+        return Task.CompletedTask;
+    }
+
+    public Task<string?> GetAsync(string key)
+    {
+        if (_cache.TryGetValue(key, out var entry))
+        {
+            if (entry.ExpiresAt.HasValue && entry.ExpiresAt.Value < DateTimeOffset.UtcNow)
+            {
+                _cache.TryRemove(key, out _);
+                return Task.FromResult<string?>(null);
+            }
+            return Task.FromResult<string?>(entry.Value);
+        }
+        return Task.FromResult<string?>(null);
+    }
+
+    private record CacheEntry(string Value, DateTimeOffset? ExpiresAt);
+}

--- a/conViver.Infrastructure/Cache/RedisCacheService.cs
+++ b/conViver.Infrastructure/Cache/RedisCacheService.cs
@@ -1,8 +1,11 @@
 using StackExchange.Redis;
 
+// ReSharper disable once CheckNamespace
+// Same namespace as interface
+
 namespace conViver.Infrastructure.Cache;
 
-public class RedisCacheService
+public class RedisCacheService : ICacheService
 {
     private readonly IDatabase _db;
 

--- a/conViver.Infrastructure/DependencyInjection.cs
+++ b/conViver.Infrastructure/DependencyInjection.cs
@@ -35,8 +35,18 @@ public static class DependencyInjection
         services.AddSingleton(AuthConfiguration.FromConfiguration(configuration));
         services.AddSingleton<JwtService>();
 
-        services.AddSingleton<IConnectionMultiplexer>(_ => ConnectionMultiplexer.Connect(configuration["REDIS_CONNECTION"] ?? "localhost:6379"));
-        services.AddSingleton<RedisCacheService>();
+        var useRedis = configuration.GetValue<bool?>("USE_REDIS") ?? true;
+        var redisConn = configuration["REDIS_CONNECTION"];
+
+        if (useRedis && !string.IsNullOrWhiteSpace(redisConn))
+        {
+            services.AddSingleton<IConnectionMultiplexer>(_ => ConnectionMultiplexer.Connect(redisConn));
+            services.AddSingleton<ICacheService, RedisCacheService>();
+        }
+        else
+        {
+            services.AddSingleton<ICacheService, InMemoryCacheService>();
+        }
 
         services.AddScoped<INotificacaoService, NotificationService>();
         services.AddScoped<IFinanceiroService, FinanceiroService>();


### PR DESCRIPTION
## Summary
- add `ICacheService` abstraction with `SetAsync`/`GetAsync`
- implement `InMemoryCacheService`
- make `RedisCacheService` implement `ICacheService`
- register cache provider based on new `USE_REDIS` setting
- inject `ICacheService` into `CachingMiddleware`
- allow local runs without Redis via `USE_REDIS=false`
- document new setting in README

## Testing
- `dotnet test` *(fails: `dotnet` not found)*

------
https://chatgpt.com/codex/tasks/task_e_685f68d42a348332acdff706703701b8