### PR TITLE
Fix: Corrige visibilidade de 'Criar Enquete' no FAB e estilos do moda…

### DIFF
--- a/conViver.Web/js/comunicacao.js
+++ b/conViver.Web/js/comunicacao.js
@@ -1,5 +1,5 @@
 import apiClient from "./apiClient.js";
-import { requireAuth } from "./auth.js";
+import { requireAuth, getUserInfo } from "./auth.js"; // Importa getUserInfo
 import { showGlobalFeedback, showSkeleton, hideSkeleton, showInlineSpinner } from "./main.js";
 import { initFabMenu } from "./fabMenu.js";
 
@@ -814,9 +814,13 @@ async function handleDeleteAviso(itemId) {
 // rely on that role should treat "Condomino" and "Inquilino" as synonyms of
 // "Morador".
 function getUserRoles() {
-  const user = JSON.parse(localStorage.getItem("userInfo"));
-  if (user && user.roles) return user.roles;
-  return ["Condomino"];
+  // const user = JSON.parse(localStorage.getItem("userInfo")); // LINHA ANTIGA
+  // if (user && user.roles) return user.roles; // LINHA ANTIGA
+  const userInfo = getUserInfo(); // NOVA LINHA: Usa a função de auth.js
+  if (userInfo && userInfo.roles) { // NOVA LINHA
+    return userInfo.roles; // NOVA LINHA
+  }
+  return ["Condomino"]; // Mantém o fallback
 }
 
 

--- a/conViver.Web/pages/comunicacao.html
+++ b/conViver.Web/pages/comunicacao.html
@@ -341,41 +341,41 @@
 
     <!-- Modal de Cadastro de Nova Ocorrência -->
     <div id="modalNovaOcorrencia" class="cv-modal" style="display:none;">
-        <div class="cv-modal__content">
-            <span class="cv-modal__close-button js-modal-criar-ocorrencia-close" id="closeNovaOcorrenciaModal">&times;</span>
+        <div class="cv-modal-content"> <!-- Alterado de cv-modal__content -->
+            <span class="cv-modal-close js-modal-criar-ocorrencia-close" id="closeNovaOcorrenciaModal">&times;</span> <!-- Alterado de cv-modal__close-button -->
             <h2>Nova Ocorrência</h2>
             <form id="formNovaOcorrencia" class="cv-form">
-                <div class="cv-form__group">
-                    <label for="ocorrenciaTitulo" class="cv-form__label">Título (obrigatório):</label>
-                    <input type="text" id="ocorrenciaTitulo" name="titulo" class="cv-form__input" required maxlength="100">
+                <div class="cv-form-group"> <!-- Alterado de cv-form__group -->
+                    <label for="ocorrenciaTitulo">Título (obrigatório):</label> <!-- Removida classe cv-form__label -->
+                    <input type="text" id="ocorrenciaTitulo" name="titulo" class="cv-input" required maxlength="100"> <!-- Alterado de cv-form__input -->
                 </div>
-                <div class="cv-form__group">
-                    <label for="ocorrenciaDescricao" class="cv-form__label">Descrição (obrigatório):</label>
-                    <textarea id="ocorrenciaDescricao" name="descricao" class="cv-form__textarea" rows="5" required maxlength="1000"></textarea>
+                <div class="cv-form-group"> <!-- Alterado de cv-form__group -->
+                    <label for="ocorrenciaDescricao">Descrição (obrigatório):</label> <!-- Removida classe cv-form__label -->
+                    <textarea id="ocorrenciaDescricao" name="descricao" class="cv-input" rows="5" required maxlength="1000"></textarea> <!-- Alterado de cv-form__textarea para cv-input -->
                 </div>
-                <div class="cv-form__group">
-                    <label for="ocorrenciaCategoria" class="cv-form__label">Categoria (obrigatório):</label>
-                    <select id="ocorrenciaCategoria" name="categoria" class="cv-form__select" required>
+                <div class="cv-form-group"> <!-- Alterado de cv-form__group -->
+                    <label for="ocorrenciaCategoria">Categoria (obrigatório):</label> <!-- Removida classe cv-form__label -->
+                    <select id="ocorrenciaCategoria" name="categoria" class="cv-input" required> <!-- Alterado de cv-form__select para cv-input -->
                         <option value="">Selecione...</option>
                         <!-- Options serão populadas pelo JS -->
                     </select>
                 </div>
-                <div class="cv-form__group">
-                    <label for="ocorrenciaPrioridade" class="cv-form__label">Prioridade:</label>
-                    <select id="ocorrenciaPrioridade" name="prioridade" class="cv-form__select">
+                <div class="cv-form-group"> <!-- Alterado de cv-form__group -->
+                    <label for="ocorrenciaPrioridade">Prioridade:</label> <!-- Removida classe cv-form__label -->
+                    <select id="ocorrenciaPrioridade" name="prioridade" class="cv-input"> <!-- Alterado de cv-form__select para cv-input -->
                         <option value="NORMAL">Normal</option>
                         <option value="URGENTE">Urgente</option>
                     </select>
                 </div>
-                <div class="cv-form__group">
-                    <label for="ocorrenciaAnexos" class="cv-form__label">Anexos (opcional, máx 10MB por arquivo):</label>
-                    <input type="file" id="ocorrenciaAnexos" name="anexos" class="cv-form__input-file" multiple accept="image/*,application/pdf,.doc,.docx,.xls,.xlsx,.txt,.aac,.mp3,.wav">
+                <div class="cv-form-group"> <!-- Alterado de cv-form__group -->
+                    <label for="ocorrenciaAnexos">Anexos (opcional, máx 10MB por arquivo):</label> <!-- Removida classe cv-form__label -->
+                    <input type="file" id="ocorrenciaAnexos" name="anexos" class="cv-input" multiple accept="image/*,application/pdf,.doc,.docx,.xls,.xlsx,.txt,.aac,.mp3,.wav"> <!-- Alterado de cv-form__input-file para cv-input -->
                     <div id="anexosPreviewContainer" class="anexos-preview"></div>
                 </div>
-                <div id="formNovaOcorrenciaErrors" class="cv-form__errors" style="display:none;"></div>
-                <div class="cv-form__actions">
-                    <button type="submit" class="cv-button cv-button--primary">Enviar Ocorrência</button>
-                    <button type="button" id="cancelNovaOcorrencia" class="cv-button cv-button--secondary js-modal-criar-ocorrencia-close">Cancelar</button>
+                <div id="formNovaOcorrenciaErrors" class="cv-form__errors" style="display:none;"></div> <!-- Mantido cv-form__errors por enquanto -->
+                <div class="cv-form-actions"> <!-- Alterado de cv-form__actions -->
+                    <button type="submit" class="cv-button primary">Enviar Ocorrência</button> <!-- Alterado de cv-button--primary -->
+                    <button type="button" id="cancelNovaOcorrencia" class="cv-button js-modal-criar-ocorrencia-close">Cancelar</button> <!-- Removido cv-button--secondary -->
                 </div>
             </form>
         </div>


### PR DESCRIPTION
…l de Ocorrência

- Altera a obtenção de papéis do usuário em comunicacao.js para usar o token JWT decodificado (via getUserInfo de auth.js), garantindo que a opção 'Criar Enquete' apareça corretamente para síndicos no menu flutuante (FAB).
- Padroniza as classes CSS do modal de criação de ocorrência (modalNovaOcorrencia) em comunicacao.html para utilizar a convenção hifenizada (ex: cv-modal-content, cv-form-group) consistente com outros modais e com os estilos definidos em styles.css, corrigindo quebras de layout.