### PR TITLE
Update skeleton delay in apiClient

### DIFF
--- a/conViver.Web/js/apiClient.js
+++ b/conViver.Web/js/apiClient.js
@@ -67,7 +67,7 @@ async function request(path, options = {}) {
         skeletonTimer = setTimeout(() => {
             displaySkeleton(skeletonTarget);
             skeletonShown = true;
-        }, 200); // Keep 200ms delay for skeletons
+        }, 350); // Show skeletons only for requests slower than ~350ms
     } else if (elementToSpin && (method === 'POST' || method === 'PUT' || method === 'PATCH' || method === 'DELETE')) {
         if (!(method === 'POST' && fetchOptions.body instanceof FormData)) { // Don't use inline spinner for FormData POSTs if progress bar is used
             removeInlineSpinner = showInlineSpinner(elementToSpin);


### PR DESCRIPTION
## Summary
- delay skeleton overlay a little longer so it's not shown for fast requests

## Testing
- `dotnet test ./conViver.Tests/conViver.Tests.csproj -v minimal`

------
https://chatgpt.com/codex/tasks/task_e_68630631d7bc8332bd68217a37b32c4f