### PR TITLE
Add debounce utility and use in library search

### DIFF
--- a/conViver.Web/js/biblioteca.js
+++ b/conViver.Web/js/biblioteca.js
@@ -1,6 +1,6 @@
 import apiClient from './apiClient.js';
 import { requireAuth, getUserRoles } from './auth.js'; // Supondo que getUserRoles exista ou será criado
-import { showGlobalFeedback, createErrorStateElement, createEmptyStateElement } from './main.js';
+import { showGlobalFeedback, createErrorStateElement, createEmptyStateElement, debounce } from './main.js';
 import { showFeedSkeleton, hideFeedSkeleton } from './skeleton.js'; // skeleton.js re-exporta de main.js
 import { createProgressBar, showProgress, xhrPost } from './progress.js';
 
@@ -41,7 +41,7 @@ function initializeBibliotecaPage() {
 
     const searchInput = document.getElementById('docSearchInput');
     const categoryFilter = document.getElementById('docCategoryFilter');
-    if (searchInput) searchInput.addEventListener('input', () => loadDocumentos());
+    if (searchInput) searchInput.addEventListener('input', debounce(loadDocumentos, 300));
     if (categoryFilter) categoryFilter.addEventListener('change', () => loadDocumentos());
 
     console.log('Página da Biblioteca inicializada.');

--- a/conViver.Web/js/main.js
+++ b/conViver.Web/js/main.js
@@ -48,6 +48,22 @@ export function delegateEvent(parentElement, eventType, selector, callback) {
 }
 
 /**
+ * Retorna uma versão "debounced" da função fornecida.
+ * A função original será executada somente após o período de
+ * inatividade definido.
+ * @param {Function} fn Função a ser executada.
+ * @param {number} delay Atraso em milissegundos.
+ * @returns {Function} Função debounced.
+ */
+export function debounce(fn, delay = 300) {
+  let timeoutId;
+  return function (...args) {
+    clearTimeout(timeoutId);
+    timeoutId = setTimeout(() => fn.apply(this, args), delay);
+  };
+}
+
+/**
  * Exibe uma mensagem de erro global para o usuário.
  * (Implementação inicial simples, pode ser expandida)
  * @param {string} message A mensagem de erro a ser exibida.


### PR DESCRIPTION
## Summary
- introduce a simple `debounce` helper in `main.js`
- use the helper to delay search requests in `biblioteca.js`

## Testing
- `node --check conViver.Web/js/main.js`
- `node --check conViver.Web/js/biblioteca.js`
- `node --experimental-modules testDebounce.js` *(debounce helper)*
- `dotnet test` *(fails: `dotnet` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6863084e6d848332bedab7028e666bb3