### PR TITLE
Improve spinner usage in auth forms

### DIFF
--- a/conViver.Web/js/register.js
+++ b/conViver.Web/js/register.js
@@ -1,4 +1,5 @@
 import apiClient from './apiClient.js';
+import { showInlineSpinner } from './main.js';
 
 document.addEventListener('DOMContentLoaded', () => {
     const registerForm = document.getElementById('registerForm');
@@ -46,7 +47,9 @@ document.addEventListener('DOMContentLoaded', () => {
         }
 
         submitButton.disabled = true;
+        const originalButtonHTML = submitButton.innerHTML;
         submitButton.textContent = 'Registrando...';
+        const removeSpinner = showInlineSpinner(submitButton);
 
         try {
             await apiClient.post('/auth/signup', {
@@ -83,7 +86,8 @@ document.addEventListener('DOMContentLoaded', () => {
             // Re-enable button unless success leads to a different state where button is not needed
             // For now, always re-enable for simplicity, allowing user to correct and resubmit.
             submitButton.disabled = false;
-            submitButton.textContent = 'Registrar';
+            submitButton.innerHTML = originalButtonHTML;
+            removeSpinner();
         }
     });
 });

--- a/conViver.Web/js/reset-password.js
+++ b/conViver.Web/js/reset-password.js
@@ -1,4 +1,5 @@
 import apiClient from './apiClient.js';
+import { showInlineSpinner } from './main.js';
 
 document.addEventListener('DOMContentLoaded', () => {
     const resetPasswordForm = document.getElementById('resetPasswordForm');
@@ -59,7 +60,9 @@ document.addEventListener('DOMContentLoaded', () => {
         }
 
         submitButton.disabled = true;
+        const originalButtonHTML = submitButton.innerHTML;
         submitButton.textContent = 'Redefinindo...';
+        const removeSpinner = showInlineSpinner(submitButton);
 
         try {
             await apiClient.post('/auth/reset-password', {
@@ -78,9 +81,10 @@ document.addEventListener('DOMContentLoaded', () => {
                 errorMessage = error.message;
             }
             showFeedback(errorMessage);
+        } finally {
             submitButton.disabled = false;
-            submitButton.textContent = 'Redefinir Senha';
+            submitButton.innerHTML = originalButtonHTML;
+            removeSpinner();
         }
-        // No finally block to re-enable button if successful, as form is hidden
     });
 });


### PR DESCRIPTION
## Summary
- import `showInlineSpinner` in register/reset-password pages
- show spinner while submitting register form
- show spinner while submitting reset password form

## Testing
- `dotnet test ./conViver.Tests/conViver.Tests.csproj --configuration Release --no-restore`

------
https://chatgpt.com/codex/tasks/task_e_6863085fc0648332a6187cbc58338a31