### PR TITLE
Remove duplicate error toast

### DIFF
--- a/conViver.Web/js/apiClient.js
+++ b/conViver.Web/js/apiClient.js
@@ -303,8 +303,9 @@ async function request(path, options = {}) {
                 `Network or unexpected error during API Request: ${method} ${url}. Error: ${error.message}`,
                 { url, requestOptions: loggedOptions, originalError: error }
             );
-            showGlobalFeedback(displayErrorMessage, 'error');
-            throw new ApiError(displayErrorMessage, null, url, loggedOptions, null); // Wrap in ApiError
+            const apiError = new ApiError(displayErrorMessage, null, url, loggedOptions, null); // Wrap in ApiError
+            apiError.handledByApiClient = true; // prevent duplicate toasts
+            throw apiError;
         }
     } finally {
         if (skeletonTimer) clearTimeout(skeletonTimer);

--- a/conViver.Web/wwwroot/js/apiClient.js
+++ b/conViver.Web/wwwroot/js/apiClient.js
@@ -97,7 +97,9 @@ async function request(path, options = {}) {
                 `Network or unexpected error during API Request: ${method} ${url}. Error: ${error.message}`,
                 { url, requestOptions: loggedOptions, originalError: error }
             );
-            throw new ApiError(`Network request failed for ${method} ${url}. ${error.message}`, null, url, loggedOptions);
+            const apiError = new ApiError(`Network request failed for ${method} ${url}. ${error.message}`, null, url, loggedOptions);
+            apiError.handledByApiClient = true;
+            throw apiError;
         }
     } finally {
         // no overlay to hide


### PR DESCRIPTION
## Summary
- avoid global feedback toast on network errors by marking them handled

## Testing
- `dotnet test conViver.Tests/conViver.Tests.csproj --no-build` *(fails: `dotnet` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6863407db64483329650321033fa9138