### PR TITLE
Ajustes finais na sub-aba Agenda do módulo Reservas

### DIFF
--- a/conViver.Web/js/reservas.js
+++ b/conViver.Web/js/reservas.js
@@ -305,26 +305,29 @@ function setupTabs() {
   if (initialActiveTab) initialActiveTab.click();
 }
 
-function toggleAgendaView(showCalendar) {
-  if (showCalendar) {
-    calendarioViewContainer.style.display = "block";
-    listViewContainer.style.display = "none";
-    viewToggleSwitch.checked = true; // Garante que o switch reflita o estado
-    // Recarregar/refetch eventos do calendário se necessário
-    calendarioReservas?.refetchEvents();
-    // Carregar lista de reservas do dia (se a data já estiver selecionada)
-    if(dataSelecionadaAgenda) carregarReservasDia(dataSelecionadaAgenda);
-  } else {
+/**
+ * Alterna a visualização na aba Agenda entre Calendário e Lista.
+ * @param {boolean} showList Se true, mostra a Lista; senão, mostra o Calendário.
+ */
+function toggleAgendaView(showList) {
+  if (showList) { // Mostrar Lista
     calendarioViewContainer.style.display = "none";
     listViewContainer.style.display = "block"; // Ou 'grid' se usar .feed-grid
-    viewToggleSwitch.checked = false; // Garante que o switch reflita o estado
-    // Carregar dados da lista se ainda não carregados
+    if (viewToggleSwitch) viewToggleSwitch.checked = true; // Switch marcado = Lista
+
     const listItemsEl = document.getElementById(listViewItemsContainerId);
     if (!listItemsEl.dataset.loadedOnce || !listItemsEl.innerHTML.trim()) {
       currentPageListView = 1;
       noMoreItemsListView = false;
       carregarReservasListView(1, false);
     }
+  } else { // Mostrar Calendário
+    calendarioViewContainer.style.display = "block";
+    listViewContainer.style.display = "none";
+    if (viewToggleSwitch) viewToggleSwitch.checked = false; // Switch desmarcado = Calendário
+
+    calendarioReservas?.refetchEvents();
+    if (dataSelecionadaAgenda) carregarReservasDia(dataSelecionadaAgenda);
   }
 }
 

--- a/conViver.Web/pages/reservas.html
+++ b/conViver.Web/pages/reservas.html
@@ -21,27 +21,18 @@
         <div class="cv-tab-content" id="content-agenda">
             <!-- Botão deslizante para alternar visualização Calendário/Lista -->
             <div class="reservas-view-toggle cv-form-group" style="display: flex; align-items: center; justify-content: flex-end; margin-bottom: var(--cv-spacing-md);">
-                <label for="view-toggle-switch" class="cv-switch-label" style="margin-right: var(--cv-spacing-sm);">Lista</label>
+                <label for="view-toggle-switch" class="cv-switch-label" style="margin-right: var(--cv-spacing-sm);">Calendário</label>
                 <label class="cv-switch">
-                    <input type="checkbox" id="view-toggle-switch" checked> <!-- Checked = Calendário por padrão -->
+                    <input type="checkbox" id="view-toggle-switch"> <!-- Desmarcado = Calendário por padrão -->
                     <span class="cv-switch-slider round"></span>
                 </label>
-                <label for="view-toggle-switch" class="cv-switch-label" style="margin-left: var(--cv-spacing-sm);">Calendário</label>
+                <label for="view-toggle-switch" class="cv-switch-label" style="margin-left: var(--cv-spacing-sm);">Lista</label>
             </div>
 
             <!-- Container para a visualização em Calendário -->
             <div id="calendario-view-container">
                 <section class="reservas-section cv-card"> <!-- Mantido o cv-card para consistência de fundo e sombra -->
-                    <h2 class="cv-section__title">Agenda Detalhada</h2>
-                    <!-- Filtros inline removidos. O select de espaço abaixo é opcional e pode ser controlado pelo modal -->
-                    <div class="cv-form-group" style="margin-bottom: var(--cv-spacing-md);">
-                        <label for="select-espaco-comum-calendario-display">Espaço Comum (Calendário):</label>
-                        <select id="select-espaco-comum-calendario-display" class="cv-input" disabled>
-                            <option value="">Todos os Espaços (do filtro)</option>
-                            <!-- Populado por JS para refletir o filtro do modal -->
-                        </select>
-                         <small>Este campo reflete o filtro de espaço aplicado no modal de filtros.</small>
-                    </div>
+                    <!-- Título e select de display removidos -->
                     <div id="calendario-reservas"></div>
                     <!-- Lista de reservas do dia selecionado no calendário -->
                     <section id="agenda-dia-list" class="js-agenda-dia-list feed-grid" style="margin-top:var(--cv-spacing-lg);">


### PR DESCRIPTION
- Remove título e select de display da visualização de calendário na aba Agenda, exibindo o calendário diretamente.
- Ajusta o switch de visualização (Calendário/Lista):
  - "Calendário" é agora a opção padrão (switch desmarcado e label à esquerda).
  - Lógica JS em `toggleAgendaView` foi invertida para corresponder ao novo estado padrão do switch (desmarcado = Calendário, marcado = Lista).
- Confirma que a ordenação não afeta a visualização de calendário, apenas as listas.