### PR TITLE
Fix calendar filter select

### DIFF
--- a/conViver.Web/pages/reservas.html
+++ b/conViver.Web/pages/reservas.html
@@ -32,7 +32,12 @@
             <!-- Container para a visualização em Calendário -->
             <div id="calendario-view-container">
                 <section class="reservas-section cv-card"> <!-- Mantido o cv-card para consistência de fundo e sombra -->
-                    <!-- Título e select de display removidos -->
+                    <div class="cv-form-group" style="margin-bottom: var(--cv-spacing-md);">
+                        <label for="select-espaco-comum-calendario-display">Espaço:</label>
+                        <select id="select-espaco-comum-calendario-display" class="cv-input">
+                            <option value="">Todos os Espaços</option>
+                        </select>
+                    </div>
                     <div id="calendario-reservas"></div>
                     <!-- Lista de reservas do dia selecionado no calendário -->
                     <section id="agenda-dia-list" class="js-agenda-dia-list feed-grid" style="margin-top:var(--cv-spacing-lg);">


### PR DESCRIPTION
## Summary
- add the missing `<select id="select-espaco-comum-calendario-display">` to reservas page

## Testing
- `dotnet test conViver.Tests/conViver.Tests.csproj --configuration Release` *(fails: dotnet not found / network restrictions)*

------
https://chatgpt.com/codex/tasks/task_e_68641127a1288332baaef159c431c0fd