### PR TITLE
Remove unused heading in calendar page

### DIFF
--- a/conViver.Web/pages/calendario.html
+++ b/conViver.Web/pages/calendario.html
@@ -35,7 +35,6 @@
                     <div id="calendario-reservas"></div>
                     <!-- Lista de reservas do dia selecionado no calendário -->
                     <section id="agenda-dia-list" class="js-agenda-dia-list feed-grid" style="margin-top:var(--cv-spacing-lg);">
-                         <h3 style="font-size: var(--cv-font-size-lg); color: var(--current-text-secondary); margin-bottom: var(--cv-spacing-md);">Reservas para o dia selecionado:</h3>
                         <div class="feed-skeleton-container" style="display:none;">
                             <div class="cv-card feed-skeleton-item"><div class="skeleton-title skeleton-block"></div><div class="skeleton-line skeleton-block"></div><div class="skeleton-line skeleton-block skeleton-line--short"></div></div>
                         </div>


### PR DESCRIPTION
## Summary
- remove the "Reservas para o dia selecionado" heading from the agenda tab

## Testing
- `dotnet test ./conViver.Tests/conViver.Tests.csproj --configuration Release --no-build` *(fails: `dotnet` not found)*

------
https://chatgpt.com/codex/tasks/task_e_68643aaa8b988332969c8423862aa168