### PR TITLE
Add FullCalendar CDN links to layout

### DIFF
--- a/conViver.Web/layout.html
+++ b/conViver.Web/layout.html
@@ -9,6 +9,7 @@
     </script>
     <link rel="stylesheet" href="css/components.css">
     <link rel="stylesheet" href="css/styles.css">
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/fullcalendar@6.1.8/index.global.min.css">
 </head>
 <body>
     <div id="global-message-banner" class="message-banner"></div>
@@ -31,6 +32,7 @@
     <nav id="mainNav"></nav>
     <main id="pageMain" class="cv-container"></main>
     <script src="js/config.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/fullcalendar@6.1.8/index.global.min.js"></script>
     <script type="module" src="js/nav.js"></script>
     <script type="module" src="js/userMenu.js"></script>
     <script type="module" src="js/main.js"></script>

--- a/conViver.Web/wwwroot/layout.html
+++ b/conViver.Web/wwwroot/layout.html
@@ -9,6 +9,7 @@
     </script>
     <link rel="stylesheet" href="css/components.css">
     <link rel="stylesheet" href="css/styles.css">
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/fullcalendar@6.1.8/index.global.min.css">
 </head>
 <body>
     <div id="global-message-banner" class="message-banner"></div>
@@ -31,6 +32,7 @@
     <nav id="mainNav"></nav>
     <main id="pageMain" class="cv-container"></main>
     <script src="js/config.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/fullcalendar@6.1.8/index.global.min.js"></script>
     <script type="module" src="js/nav.js"></script>
     <script type="module" src="js/userMenu.js"></script>
     <script type="module" src="js/main.js"></script>


### PR DESCRIPTION
## Summary
- load FullCalendar CSS/JS from CDN in layout template
- same change mirrored in wwwroot

## Testing
- `dotnet test --no-build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6864416309cc8332b992202926281c3e