### PR TITLE
Oculta lista de reservas em calendário

### DIFF
--- a/conViver.Web/pages/calendario.html
+++ b/conViver.Web/pages/calendario.html
@@ -34,7 +34,7 @@
                 <section class="reservas-section cv-card"> <!-- Mantido o cv-card para consistência de fundo e sombra -->
                     <div id="calendario-reservas"></div>
                     <!-- Lista de reservas do dia selecionado no calendário -->
-                    <section id="agenda-dia-list" class="js-agenda-dia-list feed-grid" style="margin-top:var(--cv-spacing-lg);">
+                    <section id="agenda-dia-list" class="js-agenda-dia-list feed-grid" style="margin-top:var(--cv-spacing-lg); display:none;">
                         <div class="feed-skeleton-container" style="display:none;">
                             <div class="cv-card feed-skeleton-item"><div class="skeleton-title skeleton-block"></div><div class="skeleton-line skeleton-block"></div><div class="skeleton-line skeleton-block skeleton-line--short"></div></div>
                         </div>

--- a/conViver.Web/wwwroot/pages/calendario.html
+++ b/conViver.Web/wwwroot/pages/calendario.html
@@ -41,7 +41,7 @@
                         </div>
                     </div>
                     <div id="calendario-reservas"></div>
-                    <section id="agenda-dia-list" class="js-agenda-dia-list" style="margin-top:var(--cv-spacing-lg);">
+                    <section id="agenda-dia-list" class="js-agenda-dia-list" style="margin-top:var(--cv-spacing-lg); display:none;">
                         <div class="feed-skeleton-container" style="display:none;">
                             <div class="cv-card feed-skeleton-item"><div class="skeleton-title skeleton-block"></div><div class="skeleton-line skeleton-block"></div><div class="skeleton-line skeleton-block skeleton-line--short"></div></div>
                             <div class="cv-card feed-skeleton-item"><div class="skeleton-title skeleton-block"></div><div class="skeleton-line skeleton-block"></div><div class="skeleton-line skeleton-block skeleton-line--short"></div></div>


### PR DESCRIPTION
## Resumo
- oculta a seção `agenda-dia-list` no calendário
- sincroniza o arquivo em `wwwroot`

## Testes
- `dotnet test --no-build` *(falhou: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68644247b8ac8332be573b6351b408f5