### PR TITLE
Otimizar espaço de visualização do calendário ajustando paddings

### DIFF
--- a/conViver.Web/css/calendario-custom.css
+++ b/conViver.Web/css/calendario-custom.css
@@ -5,10 +5,12 @@
     font-family: var(--current-font-family, -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol");
     background-color: var(--current-bg-secondary, #f9f9f9); /* Fundo ligeiramente off-white para o card do calendário */
     border-radius: 12px; /* Cantos arredondados como em apps Apple */
-    padding: clamp(10px, 2vw, 20px); /* Preenchimento responsivo */
+    padding: var(--cv-spacing-sm, 8px); /* Padding interno reduzido para o calendário */
     box-shadow: 0 4px 15px rgba(0,0,0,0.07); /* Sombra mais suave */
     border: 1px solid var(--current-border-subtle, #e5e5e5);
     color: var(--current-text-primary, #2c2c2c);
+    /* O height: 100% ou flex-grow: 1 pode ser necessário se o .fc precisar preencher a altura do card.
+       Isso depende da estrutura HTML e CSS do container .cv-card. Por enquanto, não adicionaremos. */
 }
 
 /* Remover a borda padrão do FullCalendar se o nosso container já tem uma */
@@ -688,4 +690,9 @@ html[data-theme='dark'] .fc .fc-daygrid-day-number:focus-visible,
 html[data-theme='dark'] .fc .fc-event:focus-visible {
     outline-color: var(--current-dark-focus-ring-color, #0a84ff);
     box-shadow: 0 0 0 3px var(--current-dark-focus-ring-shadow, rgba(10,132,255,0.3));
+}
+
+/* Otimização de Espaço: Remover padding do card que envolve o calendário */
+#calendario-view-container > .reservas-section.cv-card {
+    padding: 0; /* Remove o padding padrão de .cv-card */
 }


### PR DESCRIPTION
- Remove o padding do elemento '.cv-card' que envolve o calendário para permitir que o calendário ocupe todo o espaço do card.
- Ajusta o padding interno da classe '.fc' (aplicada ao calendário) para um valor menor e fixo (var(--cv-spacing-sm)), otimizando o espaço para o conteúdo do calendário enquanto mantém um leve respiro visual.