### PR TITLE
Refatorar UI: Ajustes finos no design iOS e correções adicionais

### DIFF
--- a/conViver.Web/css/components.css
+++ b/conViver.Web/css/components.css
@@ -469,7 +469,7 @@ html[data-theme="dark"] .cv-nav {
     border-radius: var(--cv-border-radius-md);
     transition: background-color 0.2s ease-in-out, color 0.2s ease-in-out, transform 0.1s ease-in-out;
     font-weight: 500;
-    gap: var(--cv-spacing-xs);
+    gap: var(--cv-spacing-sm); /* Aumentado de xs para sm (4px para 8px) */
 }
 .cv-nav__icon {
     width: 20px;
@@ -607,11 +607,66 @@ html[data-theme="dark"] .cv-nav__link--active:hover {
     border-radius: 50%;
 }
 /* User menu modal overrides */
-.user-menu-modal .cv-modal-content {
-    padding: var(--cv-spacing-md);
-    max-width: 300px; /* Smaller max-width for user menu modal */
-    /* Ensure it still gets the primary modal animation and shadow from styles.css */
+/* Assuming userMenuModal has the ID 'userMenuModal' or a specific class like '.user-menu-modal-instance' */
+/* Let's use a more specific selector if possible, e.g., #userMenuModal .cv-modal-content */
+/* For now, using .user-menu-modal class on the .cv-modal element */
+
+.user-menu-modal .cv-modal-content { /* Styles for the content box of the user menu */
+    /* padding: var(--cv-spacing-md); */ /* Padding is now handled by header/body/footer */
+    max-width: 280px; /* Smaller max-width for user menu modal, more like a popover */
+    border-radius: var(--cv-border-radius-md); /* Slightly smaller radius for popover feel */
+    box-shadow: var(--current-shadow-lg); /* Popovers often have a more distinct shadow */
+    /* Override general modal animation if a different one is desired, e.g., fade-in or slide-from-top */
+    /* animation: user-menu-pop-in 0.2s ease-out; */
+    /* margin-top: 60px; */ /* Control positioning with top/right */
+    /* margin-right: var(--cv-spacing-md); */ /* Control positioning with top/right */
+    margin-left: auto; /* Allows it to be pushed to the right by the parent .cv-modal flex centering */
+    position: absolute; /* Take it out of the normal flow of .cv-modal content centering */
+    top: calc(var(--cv-header-height, 60px) + var(--cv-spacing-sm)); /* Position below header; needs --cv-header-height var */
+    right: var(--cv-spacing-md);
+    width: auto; /* Let content dictate width up to max-width */
+    height: auto; /* Let content dictate height */
+    /* The parent .cv-modal provides the full screen overlay and initial centering.
+       These absolute positioning rules then place the .cv-modal-content specifically for the user menu. */
 }
+
+/* Define --cv-header-height in :root or where .cv-header is styled */
+/* Example, if header height is dynamic, JS might need to set this variable.
+   For a fixed example:
+   :root { --cv-header-height: 56px; }
+   @media (min-width: 768px) { :root { --cv-header-height: 68px; } }
+*/
+
+
+.user-menu-modal .cv-modal-header {
+    padding: var(--cv-spacing-sm) var(--cv-spacing-md); /* Smaller padding for user menu header */
+    min-height: auto; /* No strict min-height */
+}
+.user-menu-modal .cv-modal-header h2 {
+    font-size: var(--cv-font-size-md); /* Smaller title */
+    text-align: left; /* Titles in user menus are often left-aligned */
+    padding-left: 0; /* Reset padding if close button is handled differently */
+    padding-right: 30px; /* Space for close button on the right */
+}
+
+.user-menu-modal .cv-modal-body {
+    padding: var(--cv-spacing-sm) 0; /* No horizontal padding if list items span full width */
+}
+.user-menu-modal .cv-modal-footer {
+    display: none; /* User menus typically don't have a footer with OK/Cancel */
+}
+
+.user-menu-modal .cv-modal-close {
+    /* Ensure close button is correctly positioned and not overlapping */
+    top: 50%;
+    transform: translateY(-50%);
+    right: var(--cv-spacing-sm); /* Closer to the edge for smaller modal header */
+    width: 24px; /* Smaller close button */
+    height: 24px;
+    font-size: 16px;
+}
+
+
 .user-menu-list {
     list-style: none;
     margin: 0;

--- a/conViver.Web/css/styles.css
+++ b/conViver.Web/css/styles.css
@@ -169,7 +169,16 @@
 
     /* Nav specific current vars */
     --current-nav-bg: var(--cv-gray-100);
+
+    /* Header height variable */
+    --cv-header-height: 57px; /* Fallback, adjust based on actual .cv-header final height */
 }
+@media (min-width: 768px) {
+    :root {
+        --cv-header-height: 69px; /* Fallback for desktop header height */
+    }
+}
+
 
 html[data-theme="dark"] {
     --current-skeleton-bg: var(--cv-dark-gray-300);
@@ -943,24 +952,66 @@ main {
 
 .fab {
     position: fixed;
-    bottom: var(--cv-spacing-lg, 20px);
-    right: var(--cv-spacing-lg, 20px);
-    width: 48px; /* Reduced from 56px */
-    height: 48px; /* Reduced from 56px */
+    bottom: var(--cv-spacing-lg, 24px); /* Consistent spacing */
+    right: var(--cv-spacing-lg, 24px); /* Consistent spacing */
+    width: 52px; /* Increased from 48px to 52px */
+    height: 52px; /* Increased from 48px to 52px */
     background-color: var(--current-primary-blue, #007bff);
     color: var(--cv-text-on-primary, white);
     border: none;
     border-radius: 50%;
     font-size: var(--cv-font-size-lg, 22px); /* Reduced from 24px, using lg which is ~20px on mobile */
-    display: flex; /* Used flex for easier centering of icon/plus */
+    display: flex;
     align-items: center;
     justify-content: center;
-    box-shadow: var(--current-shadow-md, 0 2px 10px rgba(0,0,0,0.2)); /* Use theme variable */
+    box-shadow: var(--current-shadow-md, 0 2px 10px rgba(0,0,0,0.2));
     cursor: pointer;
-    z-index: 1050; /* Ensure it's above most content */
-    display: none; /* Initially hidden, JS will show it based on conditions */
+    z-index: 1050;
+    display: none;
     transition: background-color 0.2s ease, transform 0.15s ease-out, box-shadow 0.2s ease-out;
+    overflow: hidden; /* Hide parts of lines during transform if needed */
 }
+
+.fab-icon {
+    position: relative;
+    width: 22px; /* Size of the icon area */
+    height: 22px;
+}
+
+.fab-icon-line {
+    position: absolute;
+    background-color: var(--cv-text-on-primary, white);
+    transition: transform 0.3s ease-in-out, opacity 0.3s ease-in-out;
+    border-radius: 1px; /* Slightly rounded ends for lines */
+}
+
+.fab-icon-line--horizontal {
+    width: 100%; /* Full width of .fab-icon */
+    height: 3px; /* Thickness of the line */
+    top: 50%;
+    left: 0;
+    transform: translateY(-50%);
+}
+
+.fab-icon-line--vertical {
+    width: 3px; /* Thickness of the line */
+    height: 100%; /* Full height of .fab-icon */
+    top: 0;
+    left: 50%;
+    transform: translateX(-50%);
+}
+
+/* Transformation to X when FAB is active (e.g., menu is open) */
+/* This assumes a class '.fab--active' is toggled on the .fab button itself by JavaScript */
+.fab.fab--active .fab-icon-line--horizontal {
+    /* Rotates to form one part of the X */
+    transform: translateY(-50%) rotate(45deg);
+}
+.fab.fab--active .fab-icon-line--vertical {
+    /* Rotates to form the other part of the X */
+    transform: translateX(-50%) rotate(-45deg);
+}
+
 
 .fab:hover {
     /* iOS FAB hover usually involves a subtle scale and shadow change, not typically color change */
@@ -992,39 +1043,44 @@ main {
 
 .fab-menu-options {
     /* No longer absolute; it will be a flex item in .fab-menu */
-    /* position: absolute; */ /* Removed */
-    /* bottom: 70px; */ /* Removed, spacing handled by gap and flex order */
-    /* right: 0; */ /* Removed, alignment handled by align-items on fab-menu */
-    display: none; /* Hidden by default, shown when .fab-menu--open */
+    /* position: absolute; */
+    /* bottom: 70px; */
+    /* right: 0; */
+    display: none;
     flex-direction: column;
-    gap: var(--cv-spacing-sm, 8px); /* Increased gap slightly for better separation */
+    gap: var(--cv-spacing-sm, 8px);
     background-color: var(--current-bg-white);
     padding: var(--cv-spacing-sm, 8px);
     border-radius: var(--cv-border-radius-md, 8px);
-    box-shadow: var(--current-shadow-md, 0 2px 10px rgba(0,0,0,0.2));
-    margin-bottom: var(--cv-spacing-sm); /* Space between options and the FAB */
-    width: auto; /* Let content determine width, or set a specific one like 180px */
-    min-width: 160px; /* Ensure options are not too narrow */
+    box-shadow: var(--current-shadow-lg); /* Enhanced shadow for options pop-up */
+    margin-bottom: var(--cv-spacing-md); /* Increased space between options and the FAB (was sm) */
+    /* width: auto; */ /* Let content determine width */
+    min-width: 180px; /* Slightly wider minimum for options */
+    /* transform: translateX(calc(-50% + 26px)); */ /* Removed complex transform */
+    position: relative; /* Ensure it's part of the flex flow of fab-menu */
+    /* The parent .fab-menu has align-items: flex-end, so options will align to the right edge of the FAB's original position. */
+    /* margin-bottom provides the "above" spacing. */
+    /* To shift it slightly to the left relative to the FAB's right edge: */
+    right: var(--cv-spacing-sm); /* Shift options 8px to the left from FAB's right edge */
 }
 html[data-theme="dark"] .fab-menu-options {
-    background-color: var(--cv-dark-gray-200); /* Use a dark theme variable */
+    background-color: var(--cv-dark-gray-200);
 }
-.fab-menu--open .fab-menu-options { /* This class on .fab-menu will show options */
+.fab-menu--open .fab-menu-options {
     display: flex;
 }
-.fab-menu-options .cv-button { /* Buttons within the FAB menu */
-    width: 100%; /* Make buttons take full width of the options container */
-    justify-content: flex-start; /* Align text to the left for menu items */
-    padding: var(--cv-spacing-sm) var(--cv-spacing-md); /* Standard button padding */
-    /* Use a borderless/tinted style for menu items for iOS look */
+.fab-menu-options .cv-button {
+    width: 100%;
+    justify-content: flex-start;
+    padding: var(--cv-spacing-sm) var(--cv-spacing-md);
     background-color: transparent;
     color: var(--current-text-link);
     border: none;
 }
 .fab-menu-options .cv-button:hover {
-    background-color: var(--cv-gray-100-alpha-50); /* Subtle hover */
-    color: var(--current-text-link); /* Keep link color */
-    filter: none; /* Reset filter from general button hover if any */
+    background-color: var(--cv-gray-100-alpha-50);
+    color: var(--current-text-link);
+    filter: none;
 }
 html[data-theme="dark"] .fab-menu-options .cv-button:hover {
     background-color: var(--cv-dark-gray-100-alpha-50);
@@ -1032,10 +1088,7 @@ html[data-theme="dark"] .fab-menu-options .cv-button:hover {
 
 /* If the FAB itself is part of .fab-menu and not a separate element outside it: */
 .fab-menu > .fab {
-    /* Ensure it's ordered correctly by flex-direction-column-reverse */
-    /* No specific style needed here if .fab styles are already applied */
-    /* z-index might need to be higher if options are to appear "from behind" it */
-     z-index: 1050; /* Ensure FAB is on top of its own menu options background if they overlap */
+     z-index: 1050;
 }
 
 


### PR DESCRIPTION
- Garante que o padding dos modais seja aplicado nas seções internas (header, body, footer) e que os valores sejam adequados.
- Aumenta o espaçamento entre ícone e texto em `cv-nav__link`.
- Corrige o posicionamento do `userMenuModal` para que funcione como um popover abaixo do header, ajustando também o botão de fechar para evitar sobreposição.
- Aumenta o tamanho do botão flutuante (FAB) para 52px.
- Ajusta o posicionamento das opções do FAB (`fab-menu-options`) para aparecerem acima e ligeiramente à esquerda do FAB.
- Adiciona CSS para a animação do ícone do FAB de '+' para 'X' (requer estrutura HTML e JS correspondente para alternar a classe `.fab--active`).