### PR TITLE
Fix user menu modal initial visibility

### DIFF
--- a/conViver.Web/css/styles.css
+++ b/conViver.Web/css/styles.css
@@ -1123,7 +1123,6 @@ html[data-theme="dark"] .fab-menu-options .cv-button:hover {
     justify-content: center;
     padding: var(--cv-spacing-md); /* Add some padding for smaller screens so modal doesn't touch edges */
     box-sizing: border-box;
-    display: flex; /* ensure this is set for align/justify to work if not already flex */
 }
 
 .cv-modal-content {

--- a/conViver.Web/js/userMenu.js
+++ b/conViver.Web/js/userMenu.js
@@ -56,6 +56,9 @@ export function initUserMenu() {
     if (savedTheme) {
         document.documentElement.setAttribute('data-theme', savedTheme);
     }
+
+    // Ensure modal starts hidden after events are bound
+    closeModal();
 }
 
 document.addEventListener('DOMContentLoaded', initUserMenu);

--- a/conViver.Web/wwwroot/js/userMenu.js
+++ b/conViver.Web/wwwroot/js/userMenu.js
@@ -56,6 +56,9 @@ export function initUserMenu() {
     if (savedTheme) {
         document.documentElement.setAttribute('data-theme', savedTheme);
     }
+
+    // Ensure modal starts hidden after events are bound
+    closeModal();
 }
 
 document.addEventListener('DOMContentLoaded', initUserMenu);


### PR DESCRIPTION
## Summary
- ensure `.cv-modal` defaults to `display:none`
- hide user menu modal on init in `userMenu.js`

## Testing
- `dotnet test src/conViver.Tests/conViver.Tests.csproj --configuration Release --no-build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6864a3a76db88332a68090e286c06a5e