### PR TITLE
Improve nav link spacing

### DIFF
--- a/conViver.Web/wwwroot/css/components.css
+++ b/conViver.Web/wwwroot/css/components.css
@@ -409,7 +409,8 @@ html[data-theme="dark"] .cv-nav {
     border-radius: var(--cv-border-radius-md);
     transition: background-color 0.2s ease-in-out, color 0.2s ease-in-out, transform 0.1s ease-in-out;
     font-weight: 500;
-    gap: var(--cv-spacing-xs);
+    /* Increased gap for better separation between icon and label */
+    gap: var(--cv-spacing-sm);
 }
 .cv-nav__icon {
     width: 20px;


### PR DESCRIPTION
## Summary
- widen spacing between icon and label in `.cv-nav__link` for better legibility

## Testing
- `dotnet test --no-build` *(fails: `dotnet` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6864a3dd80788332b9e08090d05d9ce6