### PR TITLE
Improve modal spacing

### DIFF
--- a/conViver.Web/css/styles.css
+++ b/conViver.Web/css/styles.css
@@ -1142,6 +1142,11 @@ html[data-theme="dark"] .cv-modal-content {
      box-shadow: 0 12px 24px rgba(0,0,0,0.3), 0 20px 40px rgba(0,0,0,0.3);
 }
 
+/* Utility padding for modals that don't use header/body sections */
+.cv-modal-content--padded {
+    padding: var(--cv-spacing-lg);
+}
+
 .cv-modal-header {
     padding: var(--cv-spacing-md) var(--cv-spacing-lg);
     border-bottom: 1px solid var(--current-border-subtle);

--- a/conViver.Web/pages/biblioteca.html
+++ b/conViver.Web/pages/biblioteca.html
@@ -77,7 +77,7 @@
 
         <!-- Modal de Upload de Documento (para Síndico) -->
         <div id="modalUploadDocumento" class="cv-modal" style="display:none;">
-            <div class="cv-modal-content">
+            <div class="cv-modal-content cv-modal-content--padded">
                 <span class="cv-modal-close js-modal-upload-doc-close">&times;</span>
                 <h2>Upload de Novo Documento</h2>
                 <form id="formUploadDocumento" class="cv-form">

--- a/conViver.Web/pages/calendario.html
+++ b/conViver.Web/pages/calendario.html
@@ -80,7 +80,7 @@
     <!-- <button class="fab" id="fab-nova-reserva" title="Nova Reserva" style="display: none;">+</button> -->
 
     <div id="modal-filtros-reservas" class="cv-modal" style="display:none;">
-        <div class="cv-modal-content">
+        <div class="cv-modal-content cv-modal-content--padded">
             <span class="cv-modal-close js-modal-filtros-reservas-close">&times;</span>
             <h2 id="modal-filtros-reservas-title">Filtros de Reservas</h2> <!-- Título dinâmico -->
             <div class="cv-form">
@@ -156,7 +156,7 @@
     </div>
 
     <div id="modal-sort-reservas" class="cv-modal" style="display:none;">
-        <div class="cv-modal-content">
+        <div class="cv-modal-content cv-modal-content--padded">
             <span class="cv-modal-close js-modal-sort-reservas-close">&times;</span>
             <h2>Ordenação de Reservas</h2>
             <div class="cv-form">
@@ -182,7 +182,7 @@
 
     <!-- Modais Específicos de Reservas -->
     <div id="modal-nova-reserva" class="cv-modal" style="display:none;">
-        <div class="cv-modal-content">
+        <div class="cv-modal-content cv-modal-content--padded">
             <span class="cv-modal-close js-modal-nova-reserva-close">&times;</span>
             <h2 id="modal-nova-reserva-title">Solicitar Nova Reserva</h2>
             <form id="form-nova-reserva" class="cv-form">
@@ -226,7 +226,7 @@
     </div>
 
     <div id="modal-detalhe-reserva" class="cv-modal" style="display:none;">
-        <div class="cv-modal-content">
+        <div class="cv-modal-content cv-modal-content--padded">
             <span class="cv-modal-close js-modal-detalhe-reserva-close">&times;</span>
             <h2 id="modal-detalhe-reserva-title">Detalhes da Reserva</h2>
             <div id="modal-detalhe-reserva-conteudo" style="margin-bottom: var(--cv-spacing-lg);">
@@ -246,7 +246,7 @@
     </div>
 
     <div id="modal-gerenciar-espaco-comum" class="cv-modal" style="display:none;">
-        <div class="cv-modal-content">
+        <div class="cv-modal-content cv-modal-content--padded">
             <span class="cv-modal-close js-modal-gerenciar-espaco-close">&times;</span>
             <h2 id="modal-gerenciar-espaco-title">Adicionar Novo Espaço Comum</h2>
             <form id="form-gerenciar-espaco-comum" class="cv-form">
@@ -321,7 +321,7 @@
     </div>
 
     <div id="modal-termos-uso-reserva" class="cv-modal" style="display:none;">
-        <div class="cv-modal-content">
+        <div class="cv-modal-content cv-modal-content--padded">
             <span class="cv-modal-close js-modal-termos-uso-close">&times;</span>
             <h2>Termos de Uso para Reserva de Áreas Comuns</h2>
             <p>Exemplo de Termos:</p>

--- a/conViver.Web/pages/comunicacao.html
+++ b/conViver.Web/pages/comunicacao.html
@@ -115,7 +115,7 @@
     <!-- Modais Globais -->
 
     <div id="modal-filtros" class="cv-modal" style="display:none;">
-        <div class="cv-modal-content">
+        <div class="cv-modal-content cv-modal-content--padded">
             <span class="cv-modal-close js-modal-filtros-close">&times;</span>
             <h2>Filtros do Mural</h2>
             <div class="cv-form">
@@ -199,7 +199,7 @@
     </div>
 
     <div id="modal-sort" class="cv-modal" style="display:none;">
-        <div class="cv-modal-content">
+        <div class="cv-modal-content cv-modal-content--padded">
             <span class="cv-modal-close js-modal-sort-close">&times;</span>
             <h2>Ordenação</h2>
             <div class="cv-form">
@@ -220,7 +220,7 @@
     </div>
 
     <div id="modal-criar-aviso" class="cv-modal" style="display:none;">
-        <div class="cv-modal-content">
+        <div class="cv-modal-content cv-modal-content--padded">
             <span class="cv-modal-close js-modal-criar-aviso-close">&times;</span>
             <h2>Criar Novo Aviso</h2>
             <form id="form-criar-aviso" class="cv-form">
@@ -263,7 +263,7 @@
     </div>
 
     <div id="modal-enquete-detalhe" class="cv-modal" style="display:none;">
-        <div class="cv-modal-content">
+        <div class="cv-modal-content cv-modal-content--padded">
             <span class="cv-modal-close js-modal-enquete-detalhe-close">&times;</span>
             <h2 id="modal-enquete-detalhe-titulo">Detalhes da Enquete</h2>
             <div id="modal-enquete-detalhe-descricao" class="enquete-descricao" style="margin-bottom: 15px;"></div>
@@ -278,7 +278,7 @@
     </div>
 
     <div id="modal-chamado-detalhe" class="cv-modal" style="display:none;">
-        <div class="cv-modal-content">
+        <div class="cv-modal-content cv-modal-content--padded">
             <span class="cv-modal-close js-modal-chamado-detalhe-close">&times;</span>
             <h2 id="modal-chamado-detalhe-titulo">Detalhes da Solicitação</h2>
             <div id="modal-chamado-detalhe-conteudo" class="chamado-detalhe-view">
@@ -315,7 +315,7 @@
     </div>
 
     <div id="modal-criar-enquete" class="cv-modal" style="display:none;">
-        <div class="cv-modal-content">
+        <div class="cv-modal-content cv-modal-content--padded">
             <span class="cv-modal-close js-modal-criar-enquete-close">&times;</span>
             <h2 id="modal-enquete-title">Nova Enquete</h2>
             <form id="form-criar-enquete" class="cv-form">
@@ -348,7 +348,7 @@
     </div>
 
     <div id="modal-criar-chamado" class="cv-modal" style="display:none;">
-        <div class="cv-modal-content">
+        <div class="cv-modal-content cv-modal-content--padded">
             <span class="cv-modal-close js-modal-criar-chamado-close">&times;</span>
             <h2 id="modal-chamado-title">Nova Solicitação</h2>
             <form id="form-criar-chamado" class="cv-form">
@@ -393,7 +393,7 @@
 
     <!-- Modal de Cadastro de Nova Ocorrência -->
     <div id="modalNovaOcorrencia" class="cv-modal" style="display:none;">
-        <div class="cv-modal-content"> <!-- Alterado de cv-modal__content -->
+        <div class="cv-modal-content cv-modal-content--padded"> <!-- Alterado de cv-modal__content -->
             <span class="cv-modal-close js-modal-criar-ocorrencia-close" id="closeNovaOcorrenciaModal">&times;</span> <!-- Alterado de cv-modal__close-button -->
             <h2>Nova Ocorrência</h2>
             <form id="formNovaOcorrencia" class="cv-form">

--- a/conViver.Web/pages/financeiro.html
+++ b/conViver.Web/pages/financeiro.html
@@ -100,7 +100,7 @@
 
         <!-- Modal (inicialmente oculto) -->
         <div id="modalCobranca" class="cv-modal js-modal-cobranca" style="display: none;">
-            <div class="cv-modal-content"> <!-- Padronizado de __content para -content -->
+            <div class="cv-modal-content cv-modal-content--padded"> <!-- Padronizado de __content para -content -->
                 <span class="cv-modal-close js-modal-close-cobranca">&times;</span> <!-- Padronizado de __close para -close -->
                 <h3 id="modalCobrancaTitle" class="cv-modal-title">Nova Cobrança</h3> <!-- Padronizado de __title para -title (assumindo que existe ou será estilizado) -->
                 <div id="modalCobrancaBody" class="cv-modal-body"> <!-- Padronizado de __body para -body (assumindo que existe ou será estilizado) -->

--- a/conViver.Web/pages/ocorrencias.html
+++ b/conViver.Web/pages/ocorrencias.html
@@ -92,7 +92,7 @@
 
     <!-- Modal de Cadastro de Nova Ocorrência -->
     <div id="modalNovaOcorrencia" class="cv-modal" style="display:none;">
-        <div class="cv-modal-content"> <!-- Padronizado -->
+        <div class="cv-modal-content cv-modal-content--padded"> <!-- Padronizado -->
             <span class="cv-modal-close" id="closeNovaOcorrenciaModal">&times;</span> <!-- Padronizado -->
             <h2>Nova Ocorrência</h2>
             <form id="formNovaOcorrencia" class="cv-form">
@@ -134,7 +134,7 @@
 
     <!-- Modal de Detalhe da Ocorrência -->
     <div id="modalDetalheOcorrencia" class="cv-modal" style="display:none;">
-        <div class="cv-modal-content cv-modal-content--large"> <!-- Padronizado, mantendo --large se for uma variação válida -->
+        <div class="cv-modal-content cv-modal-content--large cv-modal-content--padded"> <!-- Padronizado, mantendo --large se for uma variação válida -->
             <span class="cv-modal-close" id="closeDetalheOcorrenciaModal">&times;</span> <!-- Padronizado -->
 
             <div id="detalheOcorrenciaSkeleton" class="feed-skeleton-container" style="display:none; padding-bottom: 20px;">
@@ -215,7 +215,7 @@
 
     <!-- Modal para Alterar Status -->
     <div id="modalAlterarStatus" class="cv-modal" style="display:none;">
-        <div class="cv-modal-content"> <!-- Padronizado -->
+        <div class="cv-modal-content cv-modal-content--padded"> <!-- Padronizado -->
             <span class="cv-modal-close" id="closeAlterarStatusModal">&times;</span> <!-- Padronizado -->
             <h2>Alterar Status da Ocorrência</h2>
             <form id="formAlterarStatus" class="cv-form">

--- a/conViver.Web/pages/portaria.html
+++ b/conViver.Web/pages/portaria.html
@@ -72,7 +72,7 @@
 
     <!-- Modais -->
     <div id="modal-registrar-visitante" class="cv-modal" style="display:none;">
-        <div class="cv-modal-content">
+        <div class="cv-modal-content cv-modal-content--padded">
             <span class="cv-modal-close js-modal-registrar-visitante-close">&times;</span>
             <h2>Registrar Novo Visitante</h2>
             <form id="formRegistrarVisitante" class="cv-form">
@@ -115,7 +115,7 @@
     </div>
 
     <div id="modal-filtros-portaria" class="cv-modal" style="display:none;">
-        <div class="cv-modal-content">
+        <div class="cv-modal-content cv-modal-content--padded">
             <span class="cv-modal-close js-modal-filtros-portaria-close">&times;</span>
             <h2 id="modal-filtros-portaria-title">Filtros</h2>
             <div class="cv-form">
@@ -168,7 +168,7 @@
     </div>
 
     <div id="modal-sort-portaria" class="cv-modal" style="display:none;">
-        <div class="cv-modal-content">
+        <div class="cv-modal-content cv-modal-content--padded">
             <span class="cv-modal-close js-modal-sort-portaria-close">&times;</span>
             <h2>Ordenação</h2>
             <div class="cv-form">
@@ -190,7 +190,7 @@
     </div>
 
     <div id="modal-registrar-encomenda" class="cv-modal" style="display:none;">
-        <div class="cv-modal-content">
+        <div class="cv-modal-content cv-modal-content--padded">
             <span class="cv-modal-close js-modal-registrar-encomenda-close">&times;</span>
             <h2>Registrar Nova Encomenda</h2>
             <form id="formNovaEncomenda" class="cv-form">


### PR DESCRIPTION
## Summary
- add `cv-modal-content--padded` class for consistent modal spacing
- use the new class across calendar, communication, finance, occurrences, portaria and library pages

## Testing
- `dotnet test --no-build` *(fails: `dotnet: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_6864a92ff5408332bbf84bd4e2f279ca