### PR TITLE
Atualiza estilo do fab-menu

### DIFF
--- a/conViver.Web/css/styles.css
+++ b/conViver.Web/css/styles.css
@@ -1024,13 +1024,14 @@ main {
     gap: var(--cv-spacing-sm, 8px);
     background-color: var(--current-bg-white);
     padding: var(--cv-spacing-sm, 8px);
-    border-radius: var(--cv-border-radius-md, 8px);
-    box-shadow: var(--current-shadow-lg);
+    border-radius: var(--cv-border-radius-lg, 14px);
+    box-shadow: 0 12px 24px rgba(0,0,0,0.1), 0 20px 40px rgba(0,0,0,0.1);
     min-width: 180px;
     z-index: 1051;
 }
 html[data-theme="dark"] .fab-menu-options {
     background-color: var(--cv-dark-gray-200);
+    box-shadow: 0 12px 24px rgba(0,0,0,0.3), 0 20px 40px rgba(0,0,0,0.3);
 }
 .fab-menu--open .fab-menu-options {
     display: flex;
@@ -1038,18 +1039,6 @@ html[data-theme="dark"] .fab-menu-options {
 .fab-menu-options .cv-button {
     width: 100%;
     justify-content: flex-start;
-    padding: var(--cv-spacing-sm) var(--cv-spacing-md);
-    background-color: transparent;
-    color: var(--current-text-link);
-    border: none;
-}
-.fab-menu-options .cv-button:hover {
-    background-color: var(--cv-gray-100-alpha-50);
-    color: var(--current-text-link);
-    filter: none;
-}
-html[data-theme="dark"] .fab-menu-options .cv-button:hover {
-    background-color: var(--cv-dark-gray-100-alpha-50);
 }
 
 /* If the FAB itself is part of .fab-menu and not a separate element outside it: */

--- a/conViver.Web/wwwroot/css/styles.css
+++ b/conViver.Web/wwwroot/css/styles.css
@@ -985,18 +985,20 @@ main {
     gap: var(--cv-spacing-xs, 5px);
     background-color: var(--current-bg-white);
     padding: var(--cv-spacing-sm, 8px);
-    border-radius: var(--cv-border-radius-md, 8px);
-    box-shadow: var(--current-shadow-md, 0 2px 10px rgba(0,0,0,0.2));
+    border-radius: var(--cv-border-radius-lg, 14px);
+    box-shadow: 0 12px 24px rgba(0,0,0,0.1), 0 20px 40px rgba(0,0,0,0.1);
     z-index: 1051;
 }
 html[data-theme="dark"] .fab-menu-options {
     background-color: var(--cv-dark-gray-200);
+    box-shadow: 0 12px 24px rgba(0,0,0,0.3), 0 20px 40px rgba(0,0,0,0.3);
 }
 .fab-menu--open .fab-menu-options {
     display: flex;
 }
 .fab-menu-options .cv-button {
-    width: 160px;
+    width: 100%;
+    justify-content: flex-start;
 }
 
 


### PR DESCRIPTION
## Summary
- ajusta `fab-menu-options` para usar as mesmas cores e sombras do modal
- remove customizações excessivas do botão dentro do menu

## Testing
- `dotnet test conViver.Tests/conViver.Tests.csproj --no-build --configuration Release` *(fails: `dotnet` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6864b1f67c308332ad80af730c91fc61