### PR TITLE
Improve responsive form and table styles

### DIFF
--- a/conViver.Web/css/components.css
+++ b/conViver.Web/css/components.css
@@ -643,8 +643,11 @@ html[data-theme="dark"] .cv-bottom-nav {
 /* Responsive Table Wrapper */
 .cv-table-responsive-wrapper {
     overflow-x: auto;
+    overflow-y: hidden;
+    -webkit-overflow-scrolling: touch;
     width: 100%;
     margin-bottom: var(--cv-spacing-md); /* Space below scrollable table */
+    display: block;
 }
 
 /* Apply to actual <table> elements, ensure it can be overridden for specific table needs */

--- a/conViver.Web/css/styles.css
+++ b/conViver.Web/css/styles.css
@@ -1305,6 +1305,19 @@ html[data-theme="dark"] .cv-modal-close {
     cursor: pointer;
 }
 
+/* Basic form layout */
+.cv-form {
+    display: flex;
+    flex-direction: column;
+    gap: var(--cv-spacing-md);
+}
+
+.cv-form-group {
+    display: flex;
+    flex-direction: column;
+    margin-bottom: var(--cv-spacing-md);
+}
+
 /* Styling for form elements within modal, assuming .cv-form, .cv-form-group, .cv-input, .cv-button are globally styled */
 #form-criar-aviso .cv-form-group {
     margin-bottom: var(--cv-spacing-md, 15px);
@@ -1342,6 +1355,16 @@ html[data-theme="dark"] .cv-modal-close {
     gap: var(--cv-spacing-sm, 10px); /* Space between buttons */
 }
 /* .cv-form-actions .cv-button {} */ /* General button styling is applied */
+
+@media (max-width: 576px) {
+    .cv-form-actions {
+        flex-direction: column;
+        align-items: stretch;
+    }
+    .cv-form-actions .cv-button {
+        width: 100%;
+    }
+}
 
 /* Notice Card Action Buttons */
 .communication__post-actions {

--- a/conViver.Web/wwwroot/css/components.css
+++ b/conViver.Web/wwwroot/css/components.css
@@ -511,8 +511,11 @@ html[data-theme="dark"] .cv-bottom-nav {
 /* Responsive Table Wrapper */
 .cv-table-responsive-wrapper {
     overflow-x: auto;
+    overflow-y: hidden;
+    -webkit-overflow-scrolling: touch;
     width: 100%;
     margin-bottom: var(--cv-spacing-md); /* Space below scrollable table */
+    display: block;
 }
 
 /* Apply to actual <table> elements, ensure it can be overridden for specific table needs */

--- a/conViver.Web/wwwroot/css/styles.css
+++ b/conViver.Web/wwwroot/css/styles.css
@@ -1102,6 +1102,19 @@ html[data-theme="dark"] .cv-modal-close {
     cursor: pointer;
 }
 
+/* Basic form layout */
+.cv-form {
+    display: flex;
+    flex-direction: column;
+    gap: var(--cv-spacing-md);
+}
+
+.cv-form-group {
+    display: flex;
+    flex-direction: column;
+    margin-bottom: var(--cv-spacing-md);
+}
+
 /* Styling for form elements within modal, assuming .cv-form, .cv-form-group, .cv-input, .cv-button are globally styled */
 #form-criar-aviso .cv-form-group {
     margin-bottom: var(--cv-spacing-md, 15px);
@@ -1139,6 +1152,16 @@ html[data-theme="dark"] .cv-modal-close {
     gap: var(--cv-spacing-sm, 10px); /* Space between buttons */
 }
 /* .cv-form-actions .cv-button {} */ /* General button styling is applied */
+
+@media (max-width: 576px) {
+    .cv-form-actions {
+        flex-direction: column;
+        align-items: stretch;
+    }
+    .cv-form-actions .cv-button {
+        width: 100%;
+    }
+}
 
 /* Notice Card Action Buttons */
 .communication__post-actions {


### PR DESCRIPTION
## Summary
- add base `.cv-form` and `.cv-form-group` styles
- make `.cv-form-actions` buttons full width on small screens
- allow horizontal scrolling for tables without layout break

## Testing
- `dotnet test --no-build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6865cbcae21c8332b186b1b412b17c51