### PR TITLE
Fix horizontal scrolling for tabs

### DIFF
--- a/conViver.Web/css/styles.css
+++ b/conViver.Web/css/styles.css
@@ -843,8 +843,10 @@ main {
 .cv-tabs-buttons {
     display: flex;
     flex: 1;
+    min-width: 0;
     overflow-x: auto;
     -webkit-overflow-scrolling: touch;
+    scrollbar-width: none; /* Firefox */
     gap: var(--cv-spacing-xs);
     white-space: nowrap;
 }


### PR DESCRIPTION
## Summary
- make `.cv-tabs-buttons` shrink properly by adding `min-width: 0`
- hide scrollbars in Firefox

## Testing
- `dotnet format --no-restore --verbosity diag` *(fails: command not found)*
- `dotnet test ./conViver.Tests/conViver.Tests.csproj --no-build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6865ee249d10833293c2dc7889667c55