### PR TITLE
Atualiza botões de erro

### DIFF
--- a/conViver.Web/js/comunicacao.js
+++ b/conViver.Web/js/comunicacao.js
@@ -2623,7 +2623,7 @@ async function handleCreateOcorrencia() {
 
 // --- Botão Tentar Novamente nos Error States ---
 function setupTryAgainButtons() {
-    document.querySelectorAll(".js-try-again-button").forEach(button => {
+    document.querySelectorAll(".cv-error-state__retry-button").forEach(button => {
         button.addEventListener("click", (event) => {
             const buttonEl = event.currentTarget;
             const contentId = buttonEl.dataset.contentId;

--- a/conViver.Web/js/portaria.js
+++ b/conViver.Web/js/portaria.js
@@ -687,7 +687,7 @@ function setupPortariaItemActionListeners() {
 }
 
 function setupTryAgainButtons() {
-    document.querySelectorAll(".js-try-again-button").forEach(button => {
+    document.querySelectorAll(".cv-error-state__retry-button").forEach(button => {
         button.addEventListener("click", (event) => {
             const buttonEl = event.currentTarget;
             const contentId = buttonEl.dataset.contentId; // Ex: content-visitantes, content-encomendas

--- a/conViver.Web/pages/comunicacao.html
+++ b/conViver.Web/pages/comunicacao.html
@@ -44,7 +44,7 @@
             <div class="cv-error-state" style="display: none;"> <!-- Adicionado para Erros no Mural -->
                 <img src="/img/illustrations/undraw_warning_cyit.svg" alt="Erro ao carregar mural" class="cv-empty-state__image"> <!-- Usar uma imagem de erro genérica ou específica -->
                 <p class="cv-empty-state__message">Falha ao carregar o mural. Verifique sua conexão ou tente novamente.</p>
-                <button class="cv-button cv-button--primary cv-empty-state__action js-try-again-button" data-content-id="content-mural">Tentar Novamente</button>
+                <button class="cv-button cv-button--primary cv-error-state__retry-button" data-content-id="content-mural">Tentar Novamente</button>
             </div>
         </div>
 
@@ -65,7 +65,7 @@
             <div class="cv-error-state" style="display: none;"> <!-- Adicionado para Erros em Enquetes -->
                 <img src="/img/illustrations/undraw_warning_cyit.svg" alt="Erro ao carregar enquetes" class="cv-empty-state__image">
                 <p class="cv-empty-state__message">Falha ao carregar as enquetes. Verifique sua conexão ou tente novamente.</p>
-                <button class="cv-button cv-button--primary cv-empty-state__action js-try-again-button" data-content-id="content-enquetes">Tentar Novamente</button>
+                <button class="cv-button cv-button--primary cv-error-state__retry-button" data-content-id="content-enquetes">Tentar Novamente</button>
             </div>
         </div>
 
@@ -86,7 +86,7 @@
             <div class="cv-error-state" style="display: none;"> <!-- Adicionado para Erros em Solicitações -->
                 <img src="/img/illustrations/undraw_warning_cyit.svg" alt="Erro ao carregar solicitações" class="cv-empty-state__image">
                 <p class="cv-empty-state__message">Falha ao carregar as solicitações. Verifique sua conexão ou tente novamente.</p>
-                <button class="cv-button cv-button--primary cv-empty-state__action js-try-again-button" data-content-id="content-solicitacoes">Tentar Novamente</button>
+                <button class="cv-button cv-button--primary cv-error-state__retry-button" data-content-id="content-solicitacoes">Tentar Novamente</button>
             </div>
         </div>
 
@@ -107,7 +107,7 @@
             <div class="cv-error-state" style="display: none;"> <!-- Adicionado para Erros em Ocorrências -->
                 <img src="/img/illustrations/undraw_warning_cyit.svg" alt="Erro ao carregar ocorrências" class="cv-empty-state__image">
                 <p class="cv-empty-state__message">Falha ao carregar as ocorrências. Verifique sua conexão ou tente novamente.</p>
-                <button class="cv-button cv-button--primary cv-empty-state__action js-try-again-button" data-content-id="content-ocorrencias">Tentar Novamente</button>
+                <button class="cv-button cv-button--primary cv-error-state__retry-button" data-content-id="content-ocorrencias">Tentar Novamente</button>
             </div>
         </div>
 

--- a/conViver.Web/pages/portaria.html
+++ b/conViver.Web/pages/portaria.html
@@ -42,7 +42,7 @@
             <div class="cv-error-state" style="display: none;">
                 <img src="/img/illustrations/undraw_warning_cyit.svg" alt="Erro ao carregar dados" class="cv-empty-state__image">
                 <p class="cv-empty-state__message">Falha ao carregar os dados. Verifique sua conexão ou tente novamente.</p>
-                <button class="cv-button cv-button--primary cv-empty-state__action js-try-again-button" data-content-id="content-visitantes">Tentar Novamente</button>
+                <button class="cv-button cv-button--primary cv-error-state__retry-button" data-content-id="content-visitantes">Tentar Novamente</button>
             </div>
         </div>
 
@@ -65,7 +65,7 @@
             <div class="cv-error-state" style="display: none;">
                 <img src="/img/illustrations/undraw_warning_cyit.svg" alt="Erro ao carregar encomendas" class="cv-empty-state__image">
                 <p class="cv-empty-state__message">Falha ao carregar as encomendas. Verifique sua conexão ou tente novamente.</p>
-                <button class="cv-button cv-button--primary cv-empty-state__action js-try-again-button" data-content-id="content-encomendas">Tentar Novamente</button>
+                <button class="cv-button cv-button--primary cv-error-state__retry-button" data-content-id="content-encomendas">Tentar Novamente</button>
             </div>
         </div>
 

--- a/conViver.Web/wwwroot/js/comunicacao.js
+++ b/conViver.Web/wwwroot/js/comunicacao.js
@@ -2622,7 +2622,7 @@ async function handleCreateOcorrencia() {
 
 // --- Botão Tentar Novamente nos Error States ---
 function setupTryAgainButtons() {
-    document.querySelectorAll(".js-try-again-button").forEach(button => {
+    document.querySelectorAll(".cv-error-state__retry-button").forEach(button => {
         button.addEventListener("click", (event) => {
             const buttonEl = event.currentTarget;
             const contentId = buttonEl.dataset.contentId;

--- a/conViver.Web/wwwroot/pages/comunicacao.html
+++ b/conViver.Web/wwwroot/pages/comunicacao.html
@@ -44,7 +44,7 @@
             <div class="cv-error-state" style="display: none;"> <!-- Adicionado para Erros no Mural -->
                 <img src="/img/illustrations/undraw_warning_cyit.svg" alt="Erro ao carregar mural" class="cv-empty-state__image"> <!-- Usar uma imagem de erro genérica ou específica -->
                 <p class="cv-empty-state__message">Falha ao carregar o mural. Verifique sua conexão ou tente novamente.</p>
-                <button class="cv-button cv-button--primary cv-empty-state__action js-try-again-button" data-content-id="content-mural">Tentar Novamente</button>
+                <button class="cv-button cv-button--primary cv-error-state__retry-button" data-content-id="content-mural">Tentar Novamente</button>
             </div>
         </div>
 
@@ -65,7 +65,7 @@
             <div class="cv-error-state" style="display: none;"> <!-- Adicionado para Erros em Enquetes -->
                 <img src="/img/illustrations/undraw_warning_cyit.svg" alt="Erro ao carregar enquetes" class="cv-empty-state__image">
                 <p class="cv-empty-state__message">Falha ao carregar as enquetes. Verifique sua conexão ou tente novamente.</p>
-                <button class="cv-button cv-button--primary cv-empty-state__action js-try-again-button" data-content-id="content-enquetes">Tentar Novamente</button>
+                <button class="cv-button cv-button--primary cv-error-state__retry-button" data-content-id="content-enquetes">Tentar Novamente</button>
             </div>
         </div>
 
@@ -86,7 +86,7 @@
             <div class="cv-error-state" style="display: none;"> <!-- Adicionado para Erros em Solicitações -->
                 <img src="/img/illustrations/undraw_warning_cyit.svg" alt="Erro ao carregar solicitações" class="cv-empty-state__image">
                 <p class="cv-empty-state__message">Falha ao carregar as solicitações. Verifique sua conexão ou tente novamente.</p>
-                <button class="cv-button cv-button--primary cv-empty-state__action js-try-again-button" data-content-id="content-solicitacoes">Tentar Novamente</button>
+                <button class="cv-button cv-button--primary cv-error-state__retry-button" data-content-id="content-solicitacoes">Tentar Novamente</button>
             </div>
         </div>
 
@@ -107,7 +107,7 @@
             <div class="cv-error-state" style="display: none;"> <!-- Adicionado para Erros em Ocorrências -->
                 <img src="/img/illustrations/undraw_warning_cyit.svg" alt="Erro ao carregar ocorrências" class="cv-empty-state__image">
                 <p class="cv-empty-state__message">Falha ao carregar as ocorrências. Verifique sua conexão ou tente novamente.</p>
-                <button class="cv-button cv-button--primary cv-empty-state__action js-try-again-button" data-content-id="content-ocorrencias">Tentar Novamente</button>
+                <button class="cv-button cv-button--primary cv-error-state__retry-button" data-content-id="content-ocorrencias">Tentar Novamente</button>
             </div>
         </div>
 


### PR DESCRIPTION
## Summary
- padroniza botão de retry usando `cv-error-state__retry-button`
- ajusta ouvintes nos scripts de Comunicação e Portaria

## Testing
- `dotnet test conViver.Tests/conViver.Tests.csproj --logger "trx" --results-directory ./TestResults` *(fails: Restore canceled)*

------
https://chatgpt.com/codex/tasks/task_e_686608eca73483328409e9286ba800ed