### PR TITLE
Rename scroll classes to V2 scheme

### DIFF
--- a/conViver.Web/css/styles.css
+++ b/conViver.Web/css/styles.css
@@ -194,11 +194,13 @@
     transition: opacity 0.25s ease-in-out, visibility 0s linear 0.25s;
 }
 
+.cv-header--sticky,
 .cv-header--scrolled {
     min-height: var(--cv-header-height-scrolled-mobile) !important;
     box-shadow: var(--current-shadow-md);
 }
 
+.cv-header--sticky .cv-header__title,
 .cv-header--scrolled .cv-header__title {
     opacity: 0;
     visibility: hidden;
@@ -206,6 +208,7 @@
 
 /* Desktop: mainNav sobe e cv-tabs fixa abaixo do header */
 @media (min-width: 992px) {
+    .cv-header--sticky,
     .cv-header--scrolled {
         min-height: var(--cv-header-height-scrolled-desktop) !important;
         z-index: 1005;
@@ -218,6 +221,7 @@
                     left 0.3s ease-in-out, right 0.3s ease-in-out;
     }
 
+    #mainNav.cv-nav--fixed-desktop,
     #mainNav.mainNav--fixed-top-desktop {
         position: fixed;
         top: 0; /* will be overridden dynamically via JS */
@@ -237,6 +241,7 @@
         height: var(--cv-header-height-scrolled-desktop);
     }
 
+    #mainNav.cv-nav--fixed-desktop .cv-container,
     #mainNav.mainNav--fixed-top-desktop .cv-container {
         width: 100%;
     }
@@ -246,6 +251,7 @@
                     padding-left 0.3s ease-in-out, padding-right 0.3s ease-in-out, background-color 0.3s ease-in-out;
     }
 
+    .cv-tabs.cv-tabs--sticky-desktop,
     .cv-tabs.cv-tabs--fixed-below-mainNav-desktop {
         position: fixed;
         top: var(--cv-header-height-scrolled-desktop); /* overridden dynamically */
@@ -277,6 +283,7 @@
         transition: top 0.3s ease-in-out, margin-top 0.3s ease-in-out, box-shadow 0.3s ease-in-out,
                     padding-left 0.3s ease-in-out, padding-right 0.3s ease-in-out, background-color 0.3s ease-in-out;
     }
+     .cv-tabs.cv-tabs--sticky-mobile,
      .cv-tabs.cv-tabs--fixed-mobile {
         position: fixed;
         top: var(--cv-header-height-scrolled-mobile);

--- a/conViver.Web/js/main.js
+++ b/conViver.Web/js/main.js
@@ -427,16 +427,25 @@ function handleScrollEffectsV2() {
   const isDesktop = window.innerWidth >= 992;
   const isScrolled = window.scrollY > scrollThreshold;
 
+  // V2 naming
+  header.classList.toggle('cv-header--sticky', isScrolled);
+  // Transitional support for older pages
   header.classList.toggle('cv-header--scrolled', isScrolled);
 
   if (isDesktop) {
     if (mainNav) {
+      // New class name
+      mainNav.classList.toggle('cv-nav--fixed-desktop', isScrolled);
+      // Maintain older class for compatibility
       mainNav.classList.toggle('mainNav--fixed-top-desktop', isScrolled);
       mainNav.style.top = isScrolled ? `${header.offsetHeight}px` : '';
     }
 
     if (cvTabs) {
+      cvTabs.classList.toggle('cv-tabs--sticky-desktop', isScrolled);
+      // Remove old and maintain compatibility
       cvTabs.classList.toggle('cv-tabs--fixed-below-mainNav-desktop', isScrolled);
+      cvTabs.classList.remove('cv-tabs--sticky-mobile');
       cvTabs.classList.remove('cv-tabs--fixed-mobile');
       if (isScrolled) {
         const navH = mainNav ? mainNav.offsetHeight : 0;
@@ -455,12 +464,15 @@ function handleScrollEffectsV2() {
     }
   } else {
     if (mainNav) {
+      mainNav.classList.remove('cv-nav--fixed-desktop');
       mainNav.classList.remove('mainNav--fixed-top-desktop');
       mainNav.style.top = '';
     }
 
     if (cvTabs) {
+      cvTabs.classList.toggle('cv-tabs--sticky-mobile', isScrolled);
       cvTabs.classList.toggle('cv-tabs--fixed-mobile', isScrolled);
+      cvTabs.classList.remove('cv-tabs--sticky-desktop');
       cvTabs.classList.remove('cv-tabs--fixed-below-mainNav-desktop');
       if (isScrolled) {
         cvTabs.style.top = `${header.offsetHeight}px`;

--- a/conViver.Web/wwwroot/js/main.js
+++ b/conViver.Web/wwwroot/js/main.js
@@ -438,16 +438,22 @@ function handleScrollEffectsV2() {
     const isDesktop = window.innerWidth >= 992;
     const isScrolled = window.scrollY > scrollThreshold;
 
+    // V2 naming
+    header.classList.toggle('cv-header--sticky', isScrolled);
+    // Transitional support for older pages
     header.classList.toggle('cv-header--scrolled', isScrolled);
 
     if (isDesktop) {
         if (mainNav) {
+            mainNav.classList.toggle('cv-nav--fixed-desktop', isScrolled);
             mainNav.classList.toggle('mainNav--fixed-top-desktop', isScrolled);
             mainNav.style.top = isScrolled ? `${header.offsetHeight}px` : '';
         }
 
         if (cvTabs) {
+            cvTabs.classList.toggle('cv-tabs--sticky-desktop', isScrolled);
             cvTabs.classList.toggle('cv-tabs--fixed-below-mainNav-desktop', isScrolled);
+            cvTabs.classList.remove('cv-tabs--sticky-mobile');
             cvTabs.classList.remove('cv-tabs--fixed-mobile');
             if (isScrolled) {
                 const navH = mainNav ? mainNav.offsetHeight : 0;
@@ -466,12 +472,15 @@ function handleScrollEffectsV2() {
         }
     } else {
         if (mainNav) {
+            mainNav.classList.remove('cv-nav--fixed-desktop');
             mainNav.classList.remove('mainNav--fixed-top-desktop');
             mainNav.style.top = '';
         }
 
         if (cvTabs) {
+            cvTabs.classList.toggle('cv-tabs--sticky-mobile', isScrolled);
             cvTabs.classList.toggle('cv-tabs--fixed-mobile', isScrolled);
+            cvTabs.classList.remove('cv-tabs--sticky-desktop');
             cvTabs.classList.remove('cv-tabs--fixed-below-mainNav-desktop');
             if (isScrolled) {
                 cvTabs.style.top = `${header.offsetHeight}px`;


### PR DESCRIPTION
## Summary
- rename scroll classes to their V2 names
- keep old class names as transitional aliases

## Testing
- `dotnet test --no-build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68674ebba16c8332838997e037730a6d