### PR TITLE
Implement sticky header and tabs with compact scroll effect

### DIFF
--- a/conViver.Web/css/styles.css
+++ b/conViver.Web/css/styles.css
@@ -176,128 +176,173 @@
     --cv-header-padding-y: clamp(0.5rem, 1.5vh, 0.75rem);
     --cv-header-padding-x: clamp(1rem, 4vw, 1.5rem);
     --cv-header-height: clamp(3.5rem, 5vh + 1rem, 4.3125rem); /* ~57px–69px */
-    --cv-header-height-scrolled-desktop: clamp(3rem, 4vh + 0.5rem, 3.5rem); /* Altura menor para desktop ao rolar */
-    --cv-header-height-scrolled-mobile: clamp(2.5rem, 3vh + 0.5rem, 3rem); /* Altura menor para mobile ao rolar */
+    --cv-header-height-scrolled: clamp(3rem, 4vh + 0.5rem, 3.5rem); /* Altura menor para header ao rolar */
     --cv-header-height-current: var(--cv-header-height);
-    --cv-header-slide-diff-desktop: calc(var(--cv-header-height) - var(--cv-header-height-scrolled-desktop));
-    --cv-header-slide-diff-mobile: calc(var(--cv-header-height) - var(--cv-header-height-scrolled-mobile));
+
+    /* Variáveis para cv-tabs */
+    --cv-tabs-height: clamp(2.5rem, 4vh + 0.5rem, 3rem); /* Altura normal das tabs */
+    --cv-tabs-height-scrolled: clamp(2rem, 3vh + 0.5rem, 2.5rem); /* Altura reduzida das tabs ao rolar */
+    --cv-tabs-padding-y: var(--cv-spacing-xs);
+    --cv-tabs-padding-y-scrolled: calc(var(--cv-spacing-xs) / 2);
 }
+
 @media (min-width: 768px) {
     :root {
-        --cv-header-height: clamp(4rem, 5vh + 1rem, 4.5rem);
+        --cv-header-height: clamp(4rem, 5vh + 1rem, 4.5rem); /* Header um pouco maior em desktop */
+        --cv-header-height-scrolled: clamp(3.25rem, 4.5vh + 0.5rem, 3.75rem);
+        --cv-tabs-height: clamp(2.75rem, 4.5vh + 0.5rem, 3.25rem);
+        --cv-tabs-height-scrolled: clamp(2.25rem, 3.5vh + 0.5rem, 2.75rem);
     }
 }
 
 /* Estilos para header com scroll */
 .cv-header {
-    transition: min-height 0.3s ease-in-out, box-shadow 0.3s ease-in-out;
+    transition: height 0.3s ease-in-out, box-shadow 0.3s ease-in-out, padding-top 0.3s ease-in-out, padding-bottom 0.3s ease-in-out;
+    height: var(--cv-header-height-current); /* Usa a variável de altura atual */
+    padding-top: var(--cv-header-padding-y);
+    padding-bottom: var(--cv-header-padding-y);
+    position: fixed; /* Header sempre fixo */
+    top: 0;
+    left: 0;
+    right: 0;
+    z-index: 1020; /* Acima de .cv-tabs */
+    background-color: var(--current-bg-white); /* Garante que o header tenha fundo */
 }
 
 .cv-header__title {
     transition: opacity 0.25s ease-in-out, visibility 0s linear 0.25s;
 }
 
-#headerSentinel {
-    position: absolute;
-    top: 100%;
-    width: 100%;
-    height: 1px;
-    pointer-events: none;
+#headerSentinel { /* Não mais necessário para o header, mas pode ser usado para outros efeitos de scroll */
+    /* position: absolute; */
+    /* top: 100%; */ /* Se o header não for fixo, isso ajuda a detectar scroll */
+    /* width: 100%; */
+    /* height: 1px; */
+    /* pointer-events: none; */
 }
 
 /* Nav fills available space inside header */
 #mainNav {
     flex-grow: 1;
+    /* Transições para mainNav podem ser removidas se não houver mais o efeito de slide complexo */
+    /* transition: top 0.3s ease-in-out, background-color 0.3s ease-in-out,
+                padding 0.3s ease-in-out, height 0.3s ease-in-out,
+                left 0.3s ease-in-out, right 0.3s ease-in-out,
+                transform 0.3s ease-in-out, opacity 0.3s ease-in-out; */
 }
 
 /* Ensure avatar remains above nav */
 .cv-header .user-avatar {
     position: relative;
-    z-index: 1011;
+    z-index: 1011; /* Mantém acima de outros elementos do header */
 }
 
-.cv-header--sticky,
-.cv-header--scrolled {
-    min-height: var(--cv-header-height-scrolled-mobile) !important;
+.cv-header.cv-header--compact { /* Classe para header reduzido */
+    height: var(--cv-header-height-scrolled);
     box-shadow: var(--current-shadow-md);
+    /* padding-top: calc(var(--cv-header-padding-y) * 0.8);
+    padding-bottom: calc(var(--cv-header-padding-y) * 0.8); */
 }
 
-.cv-header--sticky .cv-header__title,
-.cv-header--scrolled .cv-header__title {
+.cv-header.cv-header--compact .cv-header__title {
     opacity: 0;
     visibility: hidden;
 }
 
-/* Desktop: mainNav sobe e cv-tabs fixa abaixo do header */
-@media (min-width: 992px) {
-    .cv-header--sticky,
-    .cv-header--scrolled {
-        min-height: var(--cv-header-height-scrolled-desktop) !important;
-        z-index: 1005;
-        position: relative;
-    }
 
-    #mainNav {
-        transition: top 0.3s ease-in-out, background-color 0.3s ease-in-out,
-                    padding 0.3s ease-in-out, height 0.3s ease-in-out,
-                    left 0.3s ease-in-out, right 0.3s ease-in-out,
-                    transform 0.3s ease-in-out, opacity 0.3s ease-in-out;
-    }
-
-    #mainNav.cv-nav--fixed-desktop,
-    #mainNav.mainNav--fixed-top-desktop {
-        position: fixed;
-        top: 0; /* will be overridden dynamically via JS */
-        left: var(--cv-header-padding-x);
-        width: auto;
-        z-index: 1010;
-        background-color: var(--current-bg-white); /* Cor do header - Confirmado */
-        padding-top: 0;
-        padding-bottom: 0;
-        display: flex;
-        align-items: center;
-        height: var(--cv-header-height-scrolled-desktop);
-    }
-
-    #mainNav.cv-nav--slide {
-        transform: translateY(calc(-1 * var(--cv-header-slide-diff-desktop)));
-    }
-
-    #mainNav.cv-nav--fixed-desktop .cv-container,
-    #mainNav.mainNav--fixed-top-desktop .cv-container {
-        width: 100%;
-    }
-
-    .cv-tabs {
-        transition: top 0.3s ease-in-out, margin-top 0.3s ease-in-out, box-shadow 0.3s ease-in-out,
-                    padding-top 0.3s ease-in-out, padding-bottom 0.3s ease-in-out,
-                    padding-left 0.3s ease-in-out, padding-right 0.3s ease-in-out,
-                    background-color 0.3s ease-in-out;
-    }
-
-    .cv-tabs.cv-tabs--sticky-desktop,
-    .cv-tabs.cv-tabs--fixed-below-mainNav-desktop {
-        position: fixed;
-        top: var(--cv-header-height-current); /* overridden dynamically */
-        left: 0;
-        right: 0;
-        z-index: 1000;
-        background-color: var(--current-bg-light);
-        padding-left: var(--cv-header-padding-x);
-        padding-right: var(--cv-header-padding-x);
-        margin-top: 0;
-        border-bottom: 2px solid var(--current-border-subtle);
-        box-shadow: var(--current-shadow-sm);
-    }
-
-    #pageMain {
-        transition: padding-top 0.3s ease-in-out;
-    }
-
+/* Ajustes para cv-tabs */
+.cv-tabs {
+    position: fixed;
+    /* top é definido dinamicamente por JS */
+    left: 0;
+    right: 0;
+    z-index: 1010; /* Abaixo do header, acima do conteúdo */
+    background-color: var(--current-bg-light);
+    padding-left: var(--cv-header-padding-x); /* Usa o mesmo padding lateral do header */
+    padding-right: var(--cv-header-padding-x);
+    padding-top: var(--cv-tabs-padding-y);
+    padding-bottom: var(--cv-tabs-padding-y);
+    height: var(--cv-tabs-height);
+    border-bottom: 2px solid var(--current-border-subtle);
+    box-shadow: var(--current-shadow-sm);
+    transition: height 0.3s ease-in-out, padding-top 0.3s ease-in-out, padding-bottom 0.3s ease-in-out,
+                top 0.3s ease-in-out, box-shadow 0.3s ease-in-out, background-color 0.3s ease-in-out;
+    display: flex; /* Para alinhar itens internos */
+    align-items: center; /* Alinha verticalmente os botões das tabs */
 }
 
-/* Mobile: cv-tabs sobe e fixa abaixo do header */
+.cv-tabs.cv-tabs--compact { /* Classe para tabs reduzidas */
+    height: var(--cv-tabs-height-scrolled);
+    padding-top: var(--cv-tabs-padding-y-scrolled);
+    padding-bottom: var(--cv-tabs-padding-y-scrolled);
+    box-shadow: var(--current-shadow-sm); /* Pode manter ou ajustar a sombra */
+}
+
+.cv-tabs.cv-tabs--compact .cv-tab-button {
+    padding-top: calc(var(--cv-spacing-xs) / 2); /* Reduz padding dos botões */
+    padding-bottom: calc(var(--cv-spacing-xs) / 2);
+    font-size: 0.9rem; /* Reduz fonte dos botões */
+}
+
+
+#pageMain {
+    transition: padding-top 0.3s ease-in-out;
+    /* padding-top será ajustado por JS para acomodar header e tabs fixos */
+}
+
+
+/* Remove media queries específicas para .cv-header--sticky e .cv-tabs--sticky-*
+   pois o comportamento agora é mais unificado e controlado por JS e classes compactas. */
+
+/* @media (min-width: 992px) { ... } */
+/* @media (max-width: 991.98px) { ... } */
+
+/* As classes .cv-nav--fixed-desktop, .mainNav--fixed-top-desktop, .cv-nav--slide
+   .cv-tabs--sticky-desktop, .cv-tabs--fixed-below-mainNav-desktop
+   .cv-tabs--sticky-mobile, .cv-tabs--fixed-mobile
+   Podem ser removidas ou simplificadas se a nova lógica de header/tabs fixos e compactos
+   cobrir todos os casos de uso. */
+
+/* Exemplo de remoção/simplificação (se não forem mais usadas): */
+/*
+#mainNav.cv-nav--fixed-desktop,
+#mainNav.mainNav--fixed-top-desktop {
+    display: none;
+}
+.cv-tabs.cv-tabs--sticky-desktop,
+.cv-tabs.cv-tabs--fixed-below-mainNav-desktop,
+.cv-tabs.cv-tabs--sticky-mobile,
+.cv-tabs.cv-tabs--fixed-mobile {
+    display: none;
+}
+*/
+
+/* Se #mainNav ainda precisa de alguma lógica de fixação específica em desktop,
+   ela precisará ser reavaliada com o header sempre fixo. */
+@media (min-width: 992px) {
+    /* Se mainNav precisar se comportar diferente em desktop com header fixo */
+    /* #mainNav { ... } */
+}
+
 @media (max-width: 991.98px) {
+    /* Se mainNav precisar se comportar diferente em mobile com header fixo */
+    /* #mainNav { ... } */
+}
+
+
+/* O restante do seu CSS continua aqui... */
+/* ... */
+/* Ajuste para o conteúdo principal para não ficar atrás do header e tabs fixos */
+/* Este padding-top será gerenciado por JavaScript */
+/* #pageMain {
+    padding-top: calc(var(--cv-header-height) + var(--cv-tabs-height));
+} */
+/* Se o header e tabs mudam de tamanho, o JS precisará atualizar este padding. */
+
+
+/* Mobile: cv-tabs sobe e fixa abaixo do header */
+/* Esta seção pode ser removida ou ajustada, pois .cv-tabs é sempre fixo agora. */
+/* @media (max-width: 991.98px) {
     .cv-tabs {
         transition: top 0.3s ease-in-out, margin-top 0.3s ease-in-out, box-shadow 0.3s ease-in-out,
                     padding-top 0.3s ease-in-out, padding-bottom 0.3s ease-in-out,
@@ -325,9 +370,9 @@
     #pageMain {
         transition: padding-top 0.3s ease-in-out;
     }
-    /* padding-top will be set dynamically via JS when tabs become fixed */
-}
 
+}
+*/
 
 html[data-theme="dark"] {
     --current-skeleton-bg: var(--cv-dark-gray-300);

--- a/conViver.Web/js/main.js
+++ b/conViver.Web/js/main.js
@@ -427,126 +427,76 @@ export function clearModalError(modalElement) {
 
 /**
  * Lógica de scroll para o header e tabs.
+ * Agora o header e as tabs são sempre fixos. A função gerencia o estado "compacto"
+ * e ajusta o padding do #pageMain.
  */
-function handleScrollEffectsV2(sentinelVisible = true) {
+function handleScrollEffects() {
   const header = document.querySelector('.cv-header');
-  const mainNav = document.getElementById('mainNav');
   const cvTabs = document.querySelector('.cv-tabs');
   const pageMain = document.getElementById('pageMain');
+  // const mainNav = document.getElementById('mainNav'); // Se precisar de lógica específica para mainNav
 
-  if (!header || !pageMain) return;
-
-  const isDesktop = window.innerWidth >= 992;
-  const isScrolled = !sentinelVisible;
-
-  header.classList.toggle('cv-header--sticky', isScrolled);
-  header.classList.toggle('cv-header--scrolled', isScrolled);
-
-  updateHeaderVars();
-  const headerHeight = parseFloat(
-    getComputedStyle(document.documentElement).getPropertyValue(
-      '--cv-header-height-current'
-    )
-  ) || header.offsetHeight;
-
-  // V2 naming
-  // Transitional support for older pages
-
-  if (isDesktop) {
-    if (mainNav) {
-      // New class name
-      mainNav.classList.toggle('cv-nav--fixed-desktop', isScrolled);
-      // Maintain older class for compatibility
-      mainNav.classList.toggle('mainNav--fixed-top-desktop', isScrolled);
-      mainNav.classList.toggle('cv-nav--slide', isScrolled);
-      mainNav.style.top = isScrolled ? `${headerHeight}px` : '';
-    }
-
-    if (cvTabs) {
-      cvTabs.classList.toggle('cv-tabs--sticky-desktop', isScrolled);
-      // Remove old and maintain compatibility
-      cvTabs.classList.toggle('cv-tabs--fixed-below-mainNav-desktop', isScrolled);
-      cvTabs.classList.toggle('cv-tabs--compact', isScrolled);
-      cvTabs.classList.remove('cv-tabs--sticky-mobile');
-      cvTabs.classList.remove('cv-tabs--fixed-mobile');
-      if (isScrolled) {
-        const navH = mainNav ? mainNav.offsetHeight : 0;
-        cvTabs.style.top = `${headerHeight + navH}px`;
-      } else {
-        cvTabs.style.top = '';
-      }
-    }
-
-    if (isScrolled) {
-      const navH = mainNav ? mainNav.offsetHeight : 0;
-      const tabsH = cvTabs ? cvTabs.offsetHeight : 0;
-      pageMain.style.paddingTop = `${headerHeight + navH + tabsH}px`;
-    } else {
-      pageMain.style.paddingTop = '';
-    }
-  } else {
-    if (mainNav) {
-      mainNav.classList.remove('cv-nav--fixed-desktop');
-      mainNav.classList.remove('mainNav--fixed-top-desktop');
-      mainNav.style.top = '';
-    }
-
-    if (cvTabs) {
-      cvTabs.classList.toggle('cv-tabs--sticky-mobile', isScrolled);
-      cvTabs.classList.toggle('cv-tabs--fixed-mobile', isScrolled);
-      cvTabs.classList.toggle('cv-tabs--compact', isScrolled);
-      cvTabs.classList.remove('cv-tabs--sticky-desktop');
-      cvTabs.classList.remove('cv-tabs--fixed-below-mainNav-desktop');
-      if (isScrolled) {
-        cvTabs.style.top = `${headerHeight}px`;
-      } else {
-        cvTabs.style.top = '';
-      }
-    }
-
-    if (isScrolled) {
-      const tabsH = cvTabs ? cvTabs.offsetHeight : 0;
-      pageMain.style.paddingTop = `${headerHeight + tabsH}px`;
-    } else {
-      pageMain.style.paddingTop = '';
-    }
+  if (!header || !pageMain) {
+    debugLog("Header ou PageMain não encontrados para handleScrollEffects.");
+    return;
   }
+
+  // Determina se a página foi rolada (ex: > 0 ou com base em um sentinela se ainda usado)
+  // Para um header sempre fixo, o "scroll" pode ser qualquer valor > 0 ou uma pequena distância.
+  const isScrolled = window.scrollY > 10; // Limiar de scroll para ativar o modo compacto
+
+  // Aplica classes compactas
+  header.classList.toggle('cv-header--compact', isScrolled);
+  if (cvTabs) {
+    cvTabs.classList.toggle('cv-tabs--compact', isScrolled);
+  }
+
+  // Atualiza a variável CSS para a altura ATUAL do header (normal ou compacta)
+  // Isso é importante se a altura do header realmente muda e afeta o layout.
+  // A altura do header é agora controlada pela classe .cv-header--compact e variáveis CSS.
+  // A função updateHeaderVars pode precisar ser ajustada ou chamada aqui se necessário.
+  // Por agora, vamos assumir que as alturas CSS são suficientes.
+
+  let headerCurrentHeight = parseFloat(getComputedStyle(header).height);
+  document.documentElement.style.setProperty('--cv-header-height-current', `${headerCurrentHeight}px`);
+
+
+  let tabsCurrentHeight = 0;
+  if (cvTabs) {
+    tabsCurrentHeight = parseFloat(getComputedStyle(cvTabs).height);
+    // Define a posição 'top' das tabs para ficarem logo abaixo do header
+    cvTabs.style.top = `${headerCurrentHeight}px`;
+  }
+
+  // Ajusta o padding-top do #pageMain para acomodar o header e as tabs fixas
+  const totalFixedHeaderHeight = headerCurrentHeight + (cvTabs ? tabsCurrentHeight : 0);
+  pageMain.style.paddingTop = `${totalFixedHeaderHeight}px`;
+
+  // debugLog(`ScrollY: ${window.scrollY}, Header Compact: ${isScrolled}, Header Height: ${headerCurrentHeight}, Tabs Top: ${cvTabs ? cvTabs.style.top : 'N/A'}, PageMain PaddingTop: ${pageMain.style.paddingTop}`);
 }
 
-function initHeaderObserver() {
-  const sentinel = document.getElementById('headerSentinel');
-  if (!sentinel) return;
 
-  const observer = new IntersectionObserver((entries) => {
-    const entry = entries[0];
-    handleScrollEffectsV2(entry.isIntersecting);
-  });
+// Não precisamos mais do IntersectionObserver para o header, pois ele é sempre fixo.
+// function initHeaderObserver() { ... }
 
-  observer.observe(sentinel);
-}
+// Listener de scroll para aplicar efeitos
+window.addEventListener('scroll', debounce(handleScrollEffects, 10), { passive: true });
 
-window.addEventListener('resize', () => {
-  updateHeaderVars();
-  const sentinel = document.getElementById('headerSentinel');
-  const visible = sentinel ? sentinel.getBoundingClientRect().top >= 0 : true;
-  handleScrollEffectsV2(visible);
-});
+// Listener de resize para recalcular alturas e posições
+window.addEventListener('resize', debounce(() => {
+  updateHeaderVars(); // Garante que --cv-header-height-current é atualizado se a base mudar
+  handleScrollEffects(); // Re-aplica lógica de scroll/compacto
+}, 50));
 
-window.addEventListener(
-  'scroll',
-  () => {
-    const sentinel = document.getElementById('headerSentinel');
-    const visible = sentinel ? sentinel.getBoundingClientRect().top >= 0 : true;
-    handleScrollEffectsV2(visible);
-  },
-  { passive: true }
-);
-
+// Chamada inicial no carregamento do DOM
 document.addEventListener('DOMContentLoaded', () => {
-  updateHeaderVars();
-  initHeaderObserver();
-  const sentinel = document.getElementById('headerSentinel');
-  const visible = sentinel ? sentinel.getBoundingClientRect().top >= 0 : true;
-  handleScrollEffectsV2(visible);
-  setTimeout(() => handleScrollEffectsV2(visible), 100);
+  updateHeaderVars(); // Define a altura inicial do header
+  handleScrollEffects(); // Define o estado inicial (compacto ou não) e padding
+
+  // Adicionado um pequeno delay para garantir que todos os estilos foram aplicados
+  // e as alturas são calculadas corretamente, especialmente após o JS modificar o DOM.
+  setTimeout(() => {
+    updateHeaderVars();
+    handleScrollEffects();
+  }, 100);
 });


### PR DESCRIPTION
- Made cv-header and cv-tabs fixed to the top.
- Implemented a smooth transition effect for cv-header and cv-tabs to reduce their height and padding when the content is scrolled.
- Adjusted pageMain padding dynamically to prevent content from being obscured by the fixed elements.
- Ensured changes are responsive and tested across different screen sizes (mental walk-through).