### PR TITLE
Remove header/tab scroll compacting

### DIFF
--- a/IMPROVEMENTS_UI.md
+++ b/IMPROVEMENTS_UI.md
@@ -130,7 +130,7 @@ Diversos ajustes foram realizados para melhorar a experiência em dispositivos m
 
 ## 9. Header/MainNav/Tab Scroll Reactivity
 
-O comportamento dinâmico de compactar o cabeçalho ou fixar as abas durante a rolagem foi removido. O conteúdo rola normalmente sem que `cv-header` ou `cv-tabs` sofram alterações via JavaScript.
+O comportamento dinâmico de compactar o cabeçalho ou fixar as abas durante a rolagem foi removido. O conteúdo rola normalmente sem que `cv-header` ou `cv-tabs` sofram alterações via JavaScript. Os estilos e scripts responsáveis por essa lógica também foram eliminados do projeto.
 
 ## Conclusão
 

--- a/conViver.Web/css/styles.css
+++ b/conViver.Web/css/styles.css
@@ -176,11 +176,7 @@
     --cv-header-padding-y: clamp(0.5rem, 1.5vh, 0.75rem);
     --cv-header-padding-x: clamp(1rem, 4vw, 1.5rem);
     --cv-header-height: clamp(3.5rem, 5vh + 1rem, 4.3125rem); /* ~57px–69px */
-    --cv-header-height-scrolled-desktop: clamp(3rem, 4vh + 0.5rem, 3.5rem); /* Altura menor para desktop ao rolar */
-    --cv-header-height-scrolled-mobile: clamp(2.5rem, 3vh + 0.5rem, 3rem); /* Altura menor para mobile ao rolar */
-    --cv-header-height-current: var(--cv-header-height);
-    --cv-header-slide-diff-desktop: calc(var(--cv-header-height) - var(--cv-header-height-scrolled-desktop));
-    --cv-header-slide-diff-mobile: calc(var(--cv-header-height) - var(--cv-header-height-scrolled-mobile));
+
 }
 @media (min-width: 768px) {
     :root {
@@ -209,126 +205,7 @@
     z-index: 1011;
 }
 
-.cv-header--sticky,
-.cv-header--scrolled {
-    min-height: var(--cv-header-height-scrolled-mobile) !important;
-    box-shadow: var(--current-shadow-md);
-}
 
-.cv-header--sticky .cv-header__title,
-.cv-header--scrolled .cv-header__title {
-    opacity: 0;
-    visibility: hidden;
-}
-
-/* Desktop: mainNav sobe e cv-tabs fixa abaixo do header */
-@media (min-width: 992px) {
-    .cv-header--sticky,
-    .cv-header--scrolled {
-        min-height: var(--cv-header-height-scrolled-desktop) !important;
-        z-index: 1005;
-        position: relative;
-    }
-
-    #mainNav {
-        transition: top 0.3s ease-in-out, background-color 0.3s ease-in-out,
-                    padding 0.3s ease-in-out, height 0.3s ease-in-out,
-                    left 0.3s ease-in-out, right 0.3s ease-in-out,
-                    transform 0.3s ease-in-out, opacity 0.3s ease-in-out;
-    }
-
-    #mainNav.cv-nav--fixed-desktop,
-    #mainNav.mainNav--fixed-top-desktop {
-        position: fixed;
-        top: 0; /* will be overridden dynamically via JS */
-        left: var(--cv-header-padding-x);
-        width: auto;
-        z-index: 1010;
-        background-color: var(--current-bg-white); /* Cor do header - Confirmado */
-        padding-top: 0;
-        padding-bottom: 0;
-        display: flex;
-        align-items: center;
-        height: var(--cv-header-height-scrolled-desktop);
-    }
-
-    #mainNav.cv-nav--slide {
-        transform: translateY(calc(-1 * var(--cv-header-slide-diff-desktop)));
-    }
-
-    #mainNav.cv-nav--slide + #userMenuButton {
-        transform: translateY(calc(-1 * var(--cv-header-slide-diff-desktop)));
-        transition: transform 0.3s ease-in-out, box-shadow 0.2s ease-in-out;
-    }
-
-    #mainNav.cv-nav--fixed-desktop .cv-container,
-    #mainNav.mainNav--fixed-top-desktop .cv-container {
-        width: 100%;
-    }
-
-    .cv-tabs {
-        transition: top 0.3s ease-in-out, margin-top 0.3s ease-in-out, box-shadow 0.3s ease-in-out,
-                    padding-top 0.3s ease-in-out, padding-bottom 0.3s ease-in-out,
-                    padding-left 0.3s ease-in-out, padding-right 0.3s ease-in-out,
-                    background-color 0.3s ease-in-out;
-    }
-
-    .cv-tabs.cv-tabs--sticky-desktop,
-    .cv-tabs.cv-tabs--fixed-below-mainNav-desktop {
-        position: fixed;
-        top: var(--cv-header-height-current); /* overridden dynamically */
-        left: 0;
-        right: 0;
-        z-index: 1000;
-        background-color: var(--current-bg-light);
-        padding-left: var(--cv-header-padding-x);
-        padding-right: var(--cv-header-padding-x);
-        margin-top: 0;
-        border-bottom: 2px solid var(--current-border-subtle);
-        box-shadow: var(--current-shadow-sm);
-    }
-
-    #pageMain {
-        transition: padding-top 0.3s ease-in-out;
-    }
-
-}
-
-/* Mobile: cv-tabs sobe e fixa abaixo do header */
-@media (max-width: 991.98px) {
-    .cv-tabs {
-        transition: top 0.3s ease-in-out, margin-top 0.3s ease-in-out, box-shadow 0.3s ease-in-out,
-                    padding-top 0.3s ease-in-out, padding-bottom 0.3s ease-in-out,
-                    padding-left 0.3s ease-in-out, padding-right 0.3s ease-in-out,
-                    background-color 0.3s ease-in-out;
-    }
-    #mainNav.cv-nav--slide {
-        transform: translateY(calc(-1 * var(--cv-header-slide-diff-mobile)));
-    }
-    #mainNav.cv-nav--slide + #userMenuButton {
-        transform: translateY(calc(-1 * var(--cv-header-slide-diff-mobile)));
-        transition: transform 0.3s ease-in-out, box-shadow 0.2s ease-in-out;
-    }
-     .cv-tabs.cv-tabs--sticky-mobile,
-     .cv-tabs.cv-tabs--fixed-mobile {
-        position: fixed;
-        top: var(--cv-header-height-current);
-        left: 0;
-        right: 0;
-        z-index: 1000;
-        background-color: var(--current-bg-light);
-        padding-left: var(--cv-header-padding-x);
-        padding-right: var(--cv-header-padding-x);
-        margin-top: 0;
-        border-bottom: 2px solid var(--current-border-subtle);
-        box-shadow: var(--current-shadow-sm);
-    }
-
-    #pageMain {
-        transition: padding-top 0.3s ease-in-out;
-    }
-    /* padding-top will be set dynamically via JS when tabs become fixed */
-}
 
 
 html[data-theme="dark"] {
@@ -1005,16 +882,7 @@ main {
     border-bottom: 2px solid var(--current-border-subtle, #eee); /* Use variable or fallback */
 }
 
-/* Compact appearance when content is scrolled */
-.cv-tabs.cv-tabs--compact {
-    padding: calc(var(--cv-spacing-xs) / 2) 0;
-    margin-bottom: var(--cv-spacing-sm, 8px);
-    border-bottom-width: 1px;
-}
-.cv-tabs.cv-tabs--compact .cv-tab-button {
-    padding: 4px 10px;
-    font-size: 0.9rem;
-}
+
 
 .cv-tabs-buttons {
     display: flex;

--- a/conViver.Web/js/main.js
+++ b/conViver.Web/js/main.js
@@ -236,33 +236,6 @@ export function closeModal(modal) {
   document.body.classList.remove('cv-modal-open');
 }
 
-/**
- * Atualiza a variável CSS que representa a altura atual do header.
- */
-export function updateHeaderVars() {
-  const header = document.querySelector('.cv-header');
-  if (!header) return;
-
-  const isDesktop = window.innerWidth >= 992;
-  const isCompact = header.classList.contains('cv-header--scrolled') ||
-                    header.classList.contains('cv-header--sticky');
-
-  const rootStyles = getComputedStyle(document.documentElement);
-  const varName = isCompact
-    ? isDesktop
-      ? '--cv-header-height-scrolled-desktop'
-      : '--cv-header-height-scrolled-mobile'
-    : '--cv-header-height';
-
-  const height =
-    parseFloat(rootStyles.getPropertyValue(varName)) || header.offsetHeight;
-
-  document.documentElement.style.setProperty(
-    '--cv-header-height-current',
-    `${height}px`
-  );
-}
-
 debugLog('main.js carregado.');
 
 /**
@@ -449,74 +422,5 @@ export function clearModalError(modalElement) {
   }
 }
 
-/**
- * Lógica de scroll para o header e tabs.
- */
-function handleScrollEffectsV2() {
-  const header = document.querySelector('.cv-header');
-  const mainNav = document.getElementById('mainNav');
-  const cvTabs = document.querySelector('.cv-tabs');
-  const pageMain = document.getElementById('pageMain');
-  const scrollThreshold = 50;
 
-  if (!header || !pageMain) return;
 
-  const isDesktop = window.innerWidth >= 992;
-  const isScrolled = window.scrollY > scrollThreshold;
-
-  header.classList.toggle('cv-header--scrolled', isScrolled);
-
-  if (isDesktop) {
-    if (mainNav) {
-      mainNav.classList.toggle('mainNav--fixed-top-desktop', isScrolled);
-      mainNav.style.top = isScrolled ? `${header.offsetHeight}px` : '';
-    }
-    if (cvTabs) {
-      cvTabs.classList.toggle('cv-tabs--fixed-below-mainNav-desktop', isScrolled);
-      cvTabs.classList.remove('cv-tabs--fixed-mobile');
-      if (isScrolled) {
-        const navH = mainNav ? mainNav.offsetHeight : 0;
-        cvTabs.style.top = `${header.offsetHeight + navH}px`;
-      } else {
-        cvTabs.style.top = '';
-      }
-    }
-    if (isScrolled) {
-      const navH = mainNav ? mainNav.offsetHeight : 0;
-      const tabsH = cvTabs ? cvTabs.offsetHeight : 0;
-      pageMain.style.paddingTop = `${header.offsetHeight + navH + tabsH}px`;
-    } else {
-      pageMain.style.paddingTop = '';
-    }
-  } else {
-    if (mainNav) {
-      mainNav.classList.remove('mainNav--fixed-top-desktop');
-      mainNav.style.top = '';
-    }
-    if (cvTabs) {
-      cvTabs.classList.toggle('cv-tabs--fixed-mobile', isScrolled);
-      cvTabs.classList.remove('cv-tabs--fixed-below-mainNav-desktop');
-      if (isScrolled) {
-        cvTabs.style.top = `${header.offsetHeight}px`;
-      } else {
-        cvTabs.style.top = '';
-      }
-    }
-    if (isScrolled) {
-      const tabsH = cvTabs ? cvTabs.offsetHeight : 0;
-      pageMain.style.paddingTop = `${header.offsetHeight + tabsH}px`;
-    } else {
-      pageMain.style.paddingTop = '';
-    }
-  }
-}
-
-// Debounce para otimizar performance no scroll
-const debouncedScrollHandler = debounce(handleScrollEffectsV2, 10);
-
-window.addEventListener('scroll', debouncedScrollHandler);
-window.addEventListener('resize', debouncedScrollHandler);
-document.addEventListener('DOMContentLoaded', () => {
-  handleScrollEffectsV2();
-  setTimeout(handleScrollEffectsV2, 100);
-});

--- a/conViver.Web/wwwroot/css/styles.css
+++ b/conViver.Web/wwwroot/css/styles.css
@@ -176,11 +176,7 @@
     --cv-header-padding-y: clamp(0.5rem, 1.5vh, 0.75rem);
     --cv-header-padding-x: clamp(1rem, 4vw, 1.5rem);
     --cv-header-height: clamp(3.5rem, 5vh + 1rem, 4.3125rem); /* ~57px–69px */
-    --cv-header-height-scrolled-desktop: clamp(3rem, 4vh + 0.5rem, 3.5rem); /* Altura menor para desktop ao rolar */
-    --cv-header-height-scrolled-mobile: clamp(2.5rem, 3vh + 0.5rem, 3rem); /* Altura menor para mobile ao rolar */
-    --cv-header-height-current: var(--cv-header-height);
-    --cv-header-slide-diff-desktop: calc(var(--cv-header-height) - var(--cv-header-height-scrolled-desktop));
-    --cv-header-slide-diff-mobile: calc(var(--cv-header-height) - var(--cv-header-height-scrolled-mobile));
+
 }
 @media (min-width: 768px) {
     :root {
@@ -209,126 +205,7 @@
     z-index: 1011;
 }
 
-.cv-header--sticky,
-.cv-header--scrolled {
-    min-height: var(--cv-header-height-scrolled-mobile) !important;
-    box-shadow: var(--current-shadow-md);
-}
 
-.cv-header--sticky .cv-header__title,
-.cv-header--scrolled .cv-header__title {
-    opacity: 0;
-    visibility: hidden;
-}
-
-/* Desktop: mainNav sobe e cv-tabs fixa abaixo do header */
-@media (min-width: 992px) {
-    .cv-header--sticky,
-    .cv-header--scrolled {
-        min-height: var(--cv-header-height-scrolled-desktop) !important;
-        z-index: 1005;
-        position: relative;
-    }
-
-    #mainNav {
-        transition: top 0.3s ease-in-out, background-color 0.3s ease-in-out,
-                    padding 0.3s ease-in-out, height 0.3s ease-in-out,
-                    left 0.3s ease-in-out, right 0.3s ease-in-out,
-                    transform 0.3s ease-in-out, opacity 0.3s ease-in-out;
-    }
-
-    #mainNav.cv-nav--fixed-desktop,
-    #mainNav.mainNav--fixed-top-desktop {
-        position: fixed;
-        top: 0; /* will be overridden dynamically via JS */
-        left: var(--cv-header-padding-x);
-        width: auto;
-        z-index: 1010;
-        background-color: var(--current-bg-white); /* Cor do header - Confirmado */
-        padding-top: 0;
-        padding-bottom: 0;
-        display: flex;
-        align-items: center;
-        height: var(--cv-header-height-scrolled-desktop);
-    }
-
-    #mainNav.cv-nav--slide {
-        transform: translateY(calc(-1 * var(--cv-header-slide-diff-desktop)));
-    }
-
-    #mainNav.cv-nav--slide + #userMenuButton {
-        transform: translateY(calc(-1 * var(--cv-header-slide-diff-desktop)));
-        transition: transform 0.3s ease-in-out, box-shadow 0.2s ease-in-out;
-    }
-
-    #mainNav.cv-nav--fixed-desktop .cv-container,
-    #mainNav.mainNav--fixed-top-desktop .cv-container {
-        width: 100%;
-    }
-
-    .cv-tabs {
-        transition: top 0.3s ease-in-out, margin-top 0.3s ease-in-out, box-shadow 0.3s ease-in-out,
-                    padding-top 0.3s ease-in-out, padding-bottom 0.3s ease-in-out,
-                    padding-left 0.3s ease-in-out, padding-right 0.3s ease-in-out,
-                    background-color 0.3s ease-in-out;
-    }
-
-    .cv-tabs.cv-tabs--sticky-desktop,
-    .cv-tabs.cv-tabs--fixed-below-mainNav-desktop {
-        position: fixed;
-        top: var(--cv-header-height-current); /* overridden dynamically */
-        left: 0;
-        right: 0;
-        z-index: 1000;
-        background-color: var(--current-bg-light);
-        padding-left: var(--cv-header-padding-x);
-        padding-right: var(--cv-header-padding-x);
-        margin-top: 0;
-        border-bottom: 2px solid var(--current-border-subtle);
-        box-shadow: var(--current-shadow-sm);
-    }
-
-    #pageMain {
-        transition: padding-top 0.3s ease-in-out;
-    }
-
-}
-
-/* Mobile: cv-tabs sobe e fixa abaixo do header */
-@media (max-width: 991.98px) {
-    .cv-tabs {
-        transition: top 0.3s ease-in-out, margin-top 0.3s ease-in-out, box-shadow 0.3s ease-in-out,
-                    padding-top 0.3s ease-in-out, padding-bottom 0.3s ease-in-out,
-                    padding-left 0.3s ease-in-out, padding-right 0.3s ease-in-out,
-                    background-color 0.3s ease-in-out;
-    }
-    #mainNav.cv-nav--slide {
-        transform: translateY(calc(-1 * var(--cv-header-slide-diff-mobile)));
-    }
-    #mainNav.cv-nav--slide + #userMenuButton {
-        transform: translateY(calc(-1 * var(--cv-header-slide-diff-mobile)));
-        transition: transform 0.3s ease-in-out, box-shadow 0.2s ease-in-out;
-    }
-     .cv-tabs.cv-tabs--sticky-mobile,
-     .cv-tabs.cv-tabs--fixed-mobile {
-        position: fixed;
-        top: var(--cv-header-height-current);
-        left: 0;
-        right: 0;
-        z-index: 1000;
-        background-color: var(--current-bg-light);
-        padding-left: var(--cv-header-padding-x);
-        padding-right: var(--cv-header-padding-x);
-        margin-top: 0;
-        border-bottom: 2px solid var(--current-border-subtle);
-        box-shadow: var(--current-shadow-sm);
-    }
-
-    #pageMain {
-        transition: padding-top 0.3s ease-in-out;
-    }
-    /* padding-top will be set dynamically via JS when tabs become fixed */
-}
 
 
 html[data-theme="dark"] {
@@ -1005,16 +882,7 @@ main {
     border-bottom: 2px solid var(--current-border-subtle, #eee); /* Use variable or fallback */
 }
 
-/* Compact appearance when content is scrolled */
-.cv-tabs.cv-tabs--compact {
-    padding: calc(var(--cv-spacing-xs) / 2) 0;
-    margin-bottom: var(--cv-spacing-sm, 8px);
-    border-bottom-width: 1px;
-}
-.cv-tabs.cv-tabs--compact .cv-tab-button {
-    padding: 4px 10px;
-    font-size: 0.9rem;
-}
+
 
 .cv-tabs-buttons {
     display: flex;

--- a/conViver.Web/wwwroot/js/main.js
+++ b/conViver.Web/wwwroot/js/main.js
@@ -236,33 +236,6 @@ export function closeModal(modal) {
   document.body.classList.remove('cv-modal-open');
 }
 
-/**
- * Atualiza a variável CSS que representa a altura atual do header.
- */
-export function updateHeaderVars() {
-  const header = document.querySelector('.cv-header');
-  if (!header) return;
-
-  const isDesktop = window.innerWidth >= 992;
-  const isCompact = header.classList.contains('cv-header--scrolled') ||
-                    header.classList.contains('cv-header--sticky');
-
-  const rootStyles = getComputedStyle(document.documentElement);
-  const varName = isCompact
-    ? isDesktop
-      ? '--cv-header-height-scrolled-desktop'
-      : '--cv-header-height-scrolled-mobile'
-    : '--cv-header-height';
-
-  const height =
-    parseFloat(rootStyles.getPropertyValue(varName)) || header.offsetHeight;
-
-  document.documentElement.style.setProperty(
-    '--cv-header-height-current',
-    `${height}px`
-  );
-}
-
 debugLog('main.js carregado.');
 
 /**
@@ -449,74 +422,5 @@ export function clearModalError(modalElement) {
   }
 }
 
-/**
- * Lógica de scroll para o header e tabs.
- */
-function handleScrollEffectsV2() {
-  const header = document.querySelector('.cv-header');
-  const mainNav = document.getElementById('mainNav');
-  const cvTabs = document.querySelector('.cv-tabs');
-  const pageMain = document.getElementById('pageMain');
-  const scrollThreshold = 50;
 
-  if (!header || !pageMain) return;
 
-  const isDesktop = window.innerWidth >= 992;
-  const isScrolled = window.scrollY > scrollThreshold;
-
-  header.classList.toggle('cv-header--scrolled', isScrolled);
-
-  if (isDesktop) {
-    if (mainNav) {
-      mainNav.classList.toggle('mainNav--fixed-top-desktop', isScrolled);
-      mainNav.style.top = isScrolled ? `${header.offsetHeight}px` : '';
-    }
-    if (cvTabs) {
-      cvTabs.classList.toggle('cv-tabs--fixed-below-mainNav-desktop', isScrolled);
-      cvTabs.classList.remove('cv-tabs--fixed-mobile');
-      if (isScrolled) {
-        const navH = mainNav ? mainNav.offsetHeight : 0;
-        cvTabs.style.top = `${header.offsetHeight + navH}px`;
-      } else {
-        cvTabs.style.top = '';
-      }
-    }
-    if (isScrolled) {
-      const navH = mainNav ? mainNav.offsetHeight : 0;
-      const tabsH = cvTabs ? cvTabs.offsetHeight : 0;
-      pageMain.style.paddingTop = `${header.offsetHeight + navH + tabsH}px`;
-    } else {
-      pageMain.style.paddingTop = '';
-    }
-  } else {
-    if (mainNav) {
-      mainNav.classList.remove('mainNav--fixed-top-desktop');
-      mainNav.style.top = '';
-    }
-    if (cvTabs) {
-      cvTabs.classList.toggle('cv-tabs--fixed-mobile', isScrolled);
-      cvTabs.classList.remove('cv-tabs--fixed-below-mainNav-desktop');
-      if (isScrolled) {
-        cvTabs.style.top = `${header.offsetHeight}px`;
-      } else {
-        cvTabs.style.top = '';
-      }
-    }
-    if (isScrolled) {
-      const tabsH = cvTabs ? cvTabs.offsetHeight : 0;
-      pageMain.style.paddingTop = `${header.offsetHeight + tabsH}px`;
-    } else {
-      pageMain.style.paddingTop = '';
-    }
-  }
-}
-
-// Debounce para otimizar performance no scroll
-const debouncedScrollHandler = debounce(handleScrollEffectsV2, 10);
-
-window.addEventListener('scroll', debouncedScrollHandler);
-window.addEventListener('resize', debouncedScrollHandler);
-document.addEventListener('DOMContentLoaded', () => {
-  handleScrollEffectsV2();
-  setTimeout(handleScrollEffectsV2, 100);
-});


### PR DESCRIPTION
## Summary
- drop CSS classes and JS handlers for compact header or fixed tabs on scroll
- clean duplicated assets in wwwroot
- document removal of header/tab scroll logic

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6869484cebec83328018a12cf4d941a5