### PR TITLE
Delay header tab scroll init until page loaded

### DIFF
--- a/conViver.Web/js/headerTabsScroll.js
+++ b/conViver.Web/js/headerTabsScroll.js
@@ -1,40 +1,69 @@
-const header = document.querySelector('.cv-header');
-const tabs = document.querySelector('.cv-tabs');
+export function initHeaderTabsScroll() {
+  const header = document.querySelector('.cv-header');
+  if (!header) return;
 
-if (header && tabs) {
-  let lastScrollY = window.scrollY;
-  let isHeaderHidden = false;
-  const threshold = 10;
+  const pageMain = document.getElementById('pageMain');
+  if (!pageMain) return;
 
-  function update() {
-    const current = window.scrollY;
-    const delta = current - lastScrollY;
-    if (Math.abs(delta) <= threshold) return;
+  function attachListener(tabsEl, scrollContainer) {
+    let lastScroll = scrollContainer === window ? window.scrollY : scrollContainer.scrollTop;
+    let isHeaderHidden = false;
+    const threshold = 10;
 
-    if (delta > 0 && current > header.offsetHeight) {
-      if (!isHeaderHidden) {
-        header.classList.add('cv-header--hidden');
-        tabs.classList.add('cv-tabs--fixed');
-        isHeaderHidden = true;
+    function update() {
+      const current = scrollContainer === window ? window.scrollY : scrollContainer.scrollTop;
+      const delta = current - lastScroll;
+      if (Math.abs(delta) <= threshold) return;
+
+      if (delta > 0 && current > header.offsetHeight) {
+        if (!isHeaderHidden) {
+          header.classList.add('cv-header--hidden');
+          tabsEl.classList.add('cv-tabs--fixed');
+          isHeaderHidden = true;
+        }
+      } else if (delta < 0 || current <= 0) {
+        if (isHeaderHidden) {
+          header.classList.remove('cv-header--hidden');
+          tabsEl.classList.remove('cv-tabs--fixed');
+          isHeaderHidden = false;
+        }
       }
-    } else if (delta < 0 || current <= 0) {
-      if (isHeaderHidden) {
-        header.classList.remove('cv-header--hidden');
-        tabs.classList.remove('cv-tabs--fixed');
-        isHeaderHidden = false;
-      }
+      lastScroll = current;
     }
-    lastScrollY = current;
+
+    let ticking = false;
+    scrollContainer.addEventListener('scroll', () => {
+      if (!ticking) {
+        window.requestAnimationFrame(() => {
+          update();
+          ticking = false;
+        });
+        ticking = true;
+      }
+    });
   }
 
-  let ticking = false;
-  window.addEventListener('scroll', () => {
-    if (!ticking) {
-      window.requestAnimationFrame(() => {
-        update();
-        ticking = false;
-      });
-      ticking = true;
+  function tryInit() {
+    let tabsEl = pageMain.querySelector('.cv-tabs');
+    let scrollContainer = window;
+    if (!tabsEl) {
+      tabsEl = pageMain.querySelector('.cv-tab-content');
+      scrollContainer = tabsEl || window;
     }
-  });
+
+    if (tabsEl) {
+      attachListener(tabsEl, scrollContainer);
+      return true;
+    }
+    return false;
+  }
+
+  if (!tryInit()) {
+    const observer = new MutationObserver(() => {
+      if (tryInit()) {
+        observer.disconnect();
+      }
+    });
+    observer.observe(pageMain, { childList: true, subtree: true });
+  }
 }

--- a/conViver.Web/js/pageLoader.js
+++ b/conViver.Web/js/pageLoader.js
@@ -1,3 +1,5 @@
+import { initHeaderTabsScroll } from './headerTabsScroll.js';
+
 export async function loadPage() {
     const params = new URLSearchParams(window.location.search);
     const page = params.get('page');
@@ -17,6 +19,7 @@ export async function loadPage() {
         } catch (err) {
             console.error('Erro ao carregar script da página', err);
         }
+        initHeaderTabsScroll();
     } catch (err) {
         console.error('Erro ao carregar conteúdo da página', err);
     }

--- a/conViver.Web/layout.html
+++ b/conViver.Web/layout.html
@@ -41,7 +41,6 @@
     <script src="js/index.global.min.js"></script>
     <script type="module" src="js/nav.js"></script>
     <script type="module" src="js/userMenu.js"></script>
-    <script type="module" src="js/headerTabsScroll.js"></script>
     <script type="module" src="js/main.js"></script>
     <script type="module" src="js/pageLoader.js"></script>
 </body>

--- a/conViver.Web/wwwroot/js/headerTabsScroll.js
+++ b/conViver.Web/wwwroot/js/headerTabsScroll.js
@@ -1,40 +1,69 @@
-const header = document.querySelector('.cv-header');
-const tabs = document.querySelector('.cv-tabs');
+export function initHeaderTabsScroll() {
+  const header = document.querySelector('.cv-header');
+  if (!header) return;
 
-if (header && tabs) {
-  let lastScrollY = window.scrollY;
-  let isHeaderHidden = false;
-  const threshold = 10;
+  const pageMain = document.getElementById('pageMain');
+  if (!pageMain) return;
 
-  function update() {
-    const current = window.scrollY;
-    const delta = current - lastScrollY;
-    if (Math.abs(delta) <= threshold) return;
+  function attachListener(tabsEl, scrollContainer) {
+    let lastScroll = scrollContainer === window ? window.scrollY : scrollContainer.scrollTop;
+    let isHeaderHidden = false;
+    const threshold = 10;
 
-    if (delta > 0 && current > header.offsetHeight) {
-      if (!isHeaderHidden) {
-        header.classList.add('cv-header--hidden');
-        tabs.classList.add('cv-tabs--fixed');
-        isHeaderHidden = true;
+    function update() {
+      const current = scrollContainer === window ? window.scrollY : scrollContainer.scrollTop;
+      const delta = current - lastScroll;
+      if (Math.abs(delta) <= threshold) return;
+
+      if (delta > 0 && current > header.offsetHeight) {
+        if (!isHeaderHidden) {
+          header.classList.add('cv-header--hidden');
+          tabsEl.classList.add('cv-tabs--fixed');
+          isHeaderHidden = true;
+        }
+      } else if (delta < 0 || current <= 0) {
+        if (isHeaderHidden) {
+          header.classList.remove('cv-header--hidden');
+          tabsEl.classList.remove('cv-tabs--fixed');
+          isHeaderHidden = false;
+        }
       }
-    } else if (delta < 0 || current <= 0) {
-      if (isHeaderHidden) {
-        header.classList.remove('cv-header--hidden');
-        tabs.classList.remove('cv-tabs--fixed');
-        isHeaderHidden = false;
-      }
+      lastScroll = current;
     }
-    lastScrollY = current;
+
+    let ticking = false;
+    scrollContainer.addEventListener('scroll', () => {
+      if (!ticking) {
+        window.requestAnimationFrame(() => {
+          update();
+          ticking = false;
+        });
+        ticking = true;
+      }
+    });
   }
 
-  let ticking = false;
-  window.addEventListener('scroll', () => {
-    if (!ticking) {
-      window.requestAnimationFrame(() => {
-        update();
-        ticking = false;
-      });
-      ticking = true;
+  function tryInit() {
+    let tabsEl = pageMain.querySelector('.cv-tabs');
+    let scrollContainer = window;
+    if (!tabsEl) {
+      tabsEl = pageMain.querySelector('.cv-tab-content');
+      scrollContainer = tabsEl || window;
     }
-  });
+
+    if (tabsEl) {
+      attachListener(tabsEl, scrollContainer);
+      return true;
+    }
+    return false;
+  }
+
+  if (!tryInit()) {
+    const observer = new MutationObserver(() => {
+      if (tryInit()) {
+        observer.disconnect();
+      }
+    });
+    observer.observe(pageMain, { childList: true, subtree: true });
+  }
 }

--- a/conViver.Web/wwwroot/js/pageLoader.js
+++ b/conViver.Web/wwwroot/js/pageLoader.js
@@ -1,3 +1,5 @@
+import { initHeaderTabsScroll } from './headerTabsScroll.js';
+
 export async function loadPage() {
     const params = new URLSearchParams(window.location.search);
     const page = params.get('page');
@@ -17,6 +19,7 @@ export async function loadPage() {
         } catch (err) {
             console.error('Erro ao carregar script da página', err);
         }
+        initHeaderTabsScroll();
     } catch (err) {
         console.error('Erro ao carregar conteúdo da página', err);
     }

--- a/conViver.Web/wwwroot/layout.html
+++ b/conViver.Web/wwwroot/layout.html
@@ -41,7 +41,6 @@
     <script src="js/index.global.min.js"></script>
     <script type="module" src="js/nav.js"></script>
     <script type="module" src="js/userMenu.js"></script>
-    <script type="module" src="js/headerTabsScroll.js"></script>
     <script type="module" src="js/main.js"></script>
     <script type="module" src="js/pageLoader.js"></script>
 </body>


### PR DESCRIPTION
## Summary
- convert headerTabsScroll.js into exported function
- observe `#pageMain` to attach scroll listener when the tabs exist
- call `initHeaderTabsScroll()` from pageLoader
- remove old script reference from layout templates

## Testing
- `dotnet test --no-build` *(fails: `dotnet` not found)*

------
https://chatgpt.com/codex/tasks/task_e_686b0132287c833296dd65c00b297a91