### PR TITLE
Fix header nav alignment

### DIFF
--- a/conViver.Web/css/styles.css
+++ b/conViver.Web/css/styles.css
@@ -195,13 +195,14 @@
 }
 
 
-/* Nav fills available space inside header */
+/* Navigation next to title */
 #mainNav {
-    flex-grow: 1;
+    /* no flex-grow so items don't stretch */
 }
 
-/* Ensure avatar remains above nav */
+/* Ensure avatar remains above nav and at far right */
 .cv-header .user-avatar {
+    margin-left: auto;
     position: relative;
     z-index: 1011;
 }

--- a/conViver.Web/wwwroot/css/styles.css
+++ b/conViver.Web/wwwroot/css/styles.css
@@ -195,13 +195,14 @@
 }
 
 
-/* Nav fills available space inside header */
+/* Navigation next to title */
 #mainNav {
-    flex-grow: 1;
+    /* no flex-grow so items don't stretch */
 }
 
-/* Ensure avatar remains above nav */
+/* Ensure avatar remains above nav and at far right */
 .cv-header .user-avatar {
+    margin-left: auto;
     position: relative;
     z-index: 1011;
 }


### PR DESCRIPTION
## Summary
- remove flex-grow from header nav
- keep avatar pinned to the right with `margin-left:auto`

## Testing
- `dotnet test conViver.sln --no-build` *(fails: `dotnet` not found)*

------
https://chatgpt.com/codex/tasks/task_e_686b1cc2b5ac8332918110f082b206fd