### PR TITLE
Implement floating header on scroll down

### DIFF
--- a/conViver.Web/css/components.css
+++ b/conViver.Web/css/components.css
@@ -409,6 +409,12 @@ html[data-theme="dark"] .cv-button--borderless:hover {
 .cv-header--hidden {
     transform: translateY(-100%);
 }
+.cv-header--floating {
+    box-shadow: var(--current-shadow-sm);
+    position: sticky;
+    top: 0;
+    z-index: 1020;
+}
 .cv-header__container {
     display: flex;
     align-items: center;

--- a/conViver.Web/js/headerTabsScroll.js
+++ b/conViver.Web/js/headerTabsScroll.js
@@ -8,6 +8,7 @@ export function initHeaderTabsScroll() {
   function attachListener(tabsEl, scrollContainer) {
     let lastScroll = scrollContainer === window ? window.scrollY : scrollContainer.scrollTop;
     let isHeaderHidden = false;
+    let isFloating = false;
     const threshold = 10;
 
     function update() {
@@ -15,17 +16,32 @@ export function initHeaderTabsScroll() {
       const delta = current - lastScroll;
       if (Math.abs(delta) <= threshold) return;
 
-      if (delta > 0 && current > header.offsetHeight) {
-        if (!isHeaderHidden) {
-          header.classList.add('cv-header--hidden');
-          tabsEl.classList.add('cv-tabs--fixed');
-          isHeaderHidden = true;
+      if (current <= 0) {
+        if (isHeaderHidden || isFloating) {
+          header.classList.remove('cv-header--hidden', 'cv-header--floating');
+          tabsEl.classList.remove('cv-tabs--fixed');
+          isHeaderHidden = false;
+          isFloating = false;
         }
-      } else if (delta < 0 || current <= 0) {
+      } else if (delta > 0) {
+        // Scrolling down - show floating header
         if (isHeaderHidden) {
           header.classList.remove('cv-header--hidden');
           tabsEl.classList.remove('cv-tabs--fixed');
           isHeaderHidden = false;
+        }
+        if (!isFloating) {
+          header.classList.add('cv-header--floating');
+          isFloating = true;
+        }
+      } else if (delta < 0) {
+        // Scrolling up - hide header and fix tabs
+        if (!isHeaderHidden) {
+          header.classList.add('cv-header--hidden');
+          header.classList.remove('cv-header--floating');
+          tabsEl.classList.add('cv-tabs--fixed');
+          isHeaderHidden = true;
+          isFloating = false;
         }
       }
       lastScroll = current;

--- a/conViver.Web/wwwroot/css/components.css
+++ b/conViver.Web/wwwroot/css/components.css
@@ -409,6 +409,12 @@ html[data-theme="dark"] .cv-button--borderless:hover {
 .cv-header--hidden {
     transform: translateY(-100%);
 }
+.cv-header--floating {
+    box-shadow: var(--current-shadow-sm);
+    position: sticky;
+    top: 0;
+    z-index: 1020;
+}
 .cv-header__container {
     display: flex;
     align-items: center;

--- a/conViver.Web/wwwroot/js/headerTabsScroll.js
+++ b/conViver.Web/wwwroot/js/headerTabsScroll.js
@@ -8,6 +8,7 @@ export function initHeaderTabsScroll() {
   function attachListener(tabsEl, scrollContainer) {
     let lastScroll = scrollContainer === window ? window.scrollY : scrollContainer.scrollTop;
     let isHeaderHidden = false;
+    let isFloating = false;
     const threshold = 10;
 
     function update() {
@@ -15,17 +16,32 @@ export function initHeaderTabsScroll() {
       const delta = current - lastScroll;
       if (Math.abs(delta) <= threshold) return;
 
-      if (delta > 0 && current > header.offsetHeight) {
-        if (!isHeaderHidden) {
-          header.classList.add('cv-header--hidden');
-          tabsEl.classList.add('cv-tabs--fixed');
-          isHeaderHidden = true;
+      if (current <= 0) {
+        if (isHeaderHidden || isFloating) {
+          header.classList.remove('cv-header--hidden', 'cv-header--floating');
+          tabsEl.classList.remove('cv-tabs--fixed');
+          isHeaderHidden = false;
+          isFloating = false;
         }
-      } else if (delta < 0 || current <= 0) {
+      } else if (delta > 0) {
+        // Scrolling down - show floating header
         if (isHeaderHidden) {
           header.classList.remove('cv-header--hidden');
           tabsEl.classList.remove('cv-tabs--fixed');
           isHeaderHidden = false;
+        }
+        if (!isFloating) {
+          header.classList.add('cv-header--floating');
+          isFloating = true;
+        }
+      } else if (delta < 0) {
+        // Scrolling up - hide header and fix tabs
+        if (!isHeaderHidden) {
+          header.classList.add('cv-header--hidden');
+          header.classList.remove('cv-header--floating');
+          tabsEl.classList.add('cv-tabs--fixed');
+          isHeaderHidden = true;
+          isFloating = false;
         }
       }
       lastScroll = current;


### PR DESCRIPTION
## Summary
- add floating header logic to show header when scrolling downward
- update styles for new `.cv-header--floating` state
- sync built web assets

## Testing
- `./scripts/sync_wwwroot.sh`
- `dotnet test --no-build` *(fails: `dotnet` not found)*

------
https://chatgpt.com/codex/tasks/task_e_686b2760967483329728d960a82a10bc