### PR TITLE
feat: Implementa header flutuante no scroll

### DIFF
--- a/conViver.Web/css/styles.css
+++ b/conViver.Web/css/styles.css
@@ -187,8 +187,42 @@
 /* Estilos do header */
 .cv-header {
     transition: min-height 0.3s ease-in-out, box-shadow 0.3s ease-in-out,
-        transform 0.3s ease-in-out;
+        transform 0.3s ease-in-out, background-color 0.3s ease-in-out;
+    /* Adicionado background-color à transição */
+    position: relative; /* Para z-index funcionar corretamente no estado padrão */
+    z-index: 1010; /* Abaixo das tabs fixas e header flutuante */
+    background-color: var(--current-bg-white); /* Cor de fundo padrão */
 }
+
+.cv-header--hidden {
+    transform: translateY(-100%);
+    box-shadow: none;
+}
+
+.cv-header--floating {
+    position: fixed;
+    top: 0;
+    left: 0;
+    right: 0;
+    z-index: 1020; /* Acima do conteúdo e tabs normais, abaixo de modais */
+    box-shadow: var(--current-shadow-md);
+    /* A altura e padding são herdados do .cv-header, mas podem ser ajustados se necessário */
+    /* background-color: var(--current-bg-white); /* ou uma cor específica para o modo flutuante */
+    /* Se o header flutuante precisar de um fundo com transparência: */
+    /* background-color: rgba(255, 255, 255, 0.9); */
+    /* @supports (backdrop-filter: blur(10px)) { */
+    /*   background-color: rgba(255, 255, 255, 0.8); */
+    /*   backdrop-filter: blur(10px); */
+    /* } */
+    /* html[data-theme="dark"] & { */
+    /*   background-color: rgba(var(--cv-dark-gray-200-rgb), 0.9); /* Exemplo, se vars RGB estiverem disponíveis */
+    /*   @supports (backdrop-filter: blur(10px)) { */
+    /*     background-color: rgba(var(--cv-dark-gray-200-rgb), 0.8); */
+    /*     backdrop-filter: blur(10px); */
+    /*   } */
+    /* } */
+}
+
 
 .cv-header__title {
     transition: opacity 0.25s ease-in-out, visibility 0s linear 0.25s;
@@ -878,25 +912,50 @@ main {
 .cv-tabs {
     display: flex;
     align-items: center;
-    margin-top: var(--cv-spacing-lg, 20px);
+    margin-top: var(--cv-spacing-lg, 20px); /* Espaço original acima das tabs */
     margin-bottom: 20px;
-    padding: var(--cv-spacing-xs) 0;
+    padding: var(--cv-spacing-xs) 0; /* Padding original das tabs */
     border-bottom: 2px solid var(--current-border-subtle, #eee); /* Use variable or fallback */
-    transition: margin-top 0.3s ease-in-out, padding 0.3s ease-in-out;
+    transition: margin-top 0.3s ease-in-out, padding 0.3s ease-in-out, top 0.3s ease-in-out;
+    position: relative; /* Necessário para z-index e para que o padding-top funcione como esperado */
+    background-color: var(--current-bg-white); /* Garante fundo quando não fixo */
 }
+
 .cv-tabs--fixed {
     position: fixed;
-    top: 0;
+    /* top: 0;  Será definido por JS através de style.paddingTop no elemento .cv-tabs
+                 ou, se preferirmos, podemos usar uma variável CSS --tabs-top-offset
+                 e aplicá-la aqui. Por agora, o JS está aplicando paddingTop diretamente.
+                 Se o JS aplicar paddingTop ao invés de top, o top aqui deve ser 0.
+    */
+    top: 0; /* O JS vai adicionar paddingTop para empurrar o conteúdo das tabs para baixo */
     left: 0;
     right: 0;
-    z-index: 1015;
-    margin-top: 0;
-    padding: var(--cv-spacing-xs) var(--cv-spacing-md);
-    backdrop-filter: blur(10px);
-    background-color: rgba(255, 255, 255, 0.8);
+    z-index: 1015; /* Abaixo do header flutuante, mas acima do conteúdo da página */
+    margin-top: 0; /* Remove a margem superior quando fixo */
+     /* padding original + padding lateral para o modo fixo */
+    padding-left: var(--cv-spacing-md);
+    padding-right: var(--cv-spacing-md);
+    padding-top: var(--cv-spacing-xs); /* Padding vertical original */
+    padding-bottom: var(--cv-spacing-xs); /* Padding vertical original */
+
+    /* Efeito de vidro fosco */
+    /* A cor de fundo deve permitir que o backdrop-filter funcione */
+    background-color: rgba(255, 255, 255, 0.8); /* Light theme */
+    @supports (backdrop-filter: blur(10px)) or (-webkit-backdrop-filter: blur(10px)) {
+        backdrop-filter: blur(10px);
+        -webkit-backdrop-filter: blur(10px);
+        background-color: rgba(255, 255, 255, 0.75); /* Ligeiramente mais transparente com blur */
+    }
 }
+
 html[data-theme="dark"] .cv-tabs--fixed {
-    background-color: rgba(44, 44, 46, 0.75);
+    background-color: rgba(44, 44, 46, 0.8); /* Dark theme (cor de --cv-dark-gray-200 com alpha) */
+    @supports (backdrop-filter: blur(10px)) or (-webkit-backdrop-filter: blur(10px)) {
+        backdrop-filter: blur(10px);
+        -webkit-backdrop-filter: blur(10px);
+        background-color: rgba(44, 44, 46, 0.75); /* Ligeiramente mais transparente com blur */
+    }
 }
 
 

--- a/conViver.Web/js/headerTabsScroll.js
+++ b/conViver.Web/js/headerTabsScroll.js
@@ -6,29 +6,93 @@ export function initHeaderTabsScroll() {
   if (!pageMain) return;
 
   function attachListener(tabsEl, scrollContainer) {
-    let lastScroll = scrollContainer === window ? window.scrollY : scrollContainer.scrollTop;
-    let isHeaderHidden = false;
-    const threshold = 10;
+    let lastScrollY = scrollContainer === window ? window.scrollY : scrollContainer.scrollTop;
+    // headerState can be 'default', 'hidden', 'floating'
+    let headerState = 'default';
+    const threshold = 5; // Reduced threshold for quicker response
+    let headerHeight = header.offsetHeight;
+
+    // Function to update header height (e.g., if it changes dynamically)
+    function updateHeaderHeight() {
+        // Ensure we get the correct height, considering box-sizing and potential margins
+        const styles = window.getComputedStyle(header);
+        headerHeight = header.offsetHeight + parseFloat(styles.marginTop) + parseFloat(styles.marginBottom);
+    }
+    // Initial header height
+    updateHeaderHeight();
+
 
     function update() {
-      const current = scrollContainer === window ? window.scrollY : scrollContainer.scrollTop;
-      const delta = current - lastScroll;
-      if (Math.abs(delta) <= threshold) return;
+      const currentScrollY = scrollContainer === window ? window.scrollY : scrollContainer.scrollTop;
+      const scrollDelta = currentScrollY - lastScrollY;
 
-      if (delta > 0 && current > header.offsetHeight) {
-        if (!isHeaderHidden) {
-          header.classList.add('cv-header--hidden');
-          tabsEl.classList.add('cv-tabs--fixed');
-          isHeaderHidden = true;
-        }
-      } else if (delta < 0 || current <= 0) {
-        if (isHeaderHidden) {
-          header.classList.remove('cv-header--hidden');
+      // Update header height dynamically in case of window resize or content change
+      // This might be too frequent; consider debouncing or observing resize if performance issues arise.
+      updateHeaderHeight();
+
+      // At the very top of the page
+      if (currentScrollY <= 0) {
+        if (headerState !== 'default') {
+          header.classList.remove('cv-header--hidden', 'cv-header--floating');
           tabsEl.classList.remove('cv-tabs--fixed');
-          isHeaderHidden = false;
+          tabsEl.style.paddingTop = ''; // Reset padding/margin for tabs
+          headerState = 'default';
+        }
+      } else {
+        // Scrolling down
+        if (scrollDelta > threshold) {
+          if (headerState !== 'floating') {
+            header.classList.remove('cv-header--hidden');
+            header.classList.add('cv-header--floating');
+            tabsEl.classList.add('cv-tabs--fixed');
+            // Adjust tabs position to be below the floating header
+            tabsEl.style.paddingTop = `${headerHeight}px`;
+            headerState = 'floating';
+          }
+        }
+        // Scrolling up
+        else if (scrollDelta < -threshold) {
+          // If scrolling up and header is floating, it remains floating.
+          // If it was hidden, it remains hidden (until scroll down or top).
+          // If it was default (only possible if currentScrollY became > 0 without significant delta),
+          // then it should transition to hidden or floating based on new logic.
+
+          // The new requirement: header appears on scroll down and stays.
+          // It only hides if user scrolls up *before* it became floating,
+          // or if we explicitly want it to hide on scroll up when not at top.
+          // For now, let's stick to: if it's floating, it stays floating when scrolling up.
+          // If it's 'default' and we scrolled down a bit (currentScrollY > 0 but not enough for floating yet)
+          // and then scroll up, it should hide.
+          if (headerState === 'default' && currentScrollY > headerHeight) {
+            // This case handles if we scrolled down a bit from top, then immediately up
+            // header.classList.add('cv-header--hidden');
+            // tabsEl.classList.add('cv-tabs--fixed');
+            // tabsEl.style.paddingTop = ''; // Tabs fixed to viewport top
+            // headerState = 'hidden';
+            // On second thought, the new requirement is simpler:
+            // Header becomes floating on any scroll down (not 0), and stays.
+            // It only hides if scrolling up *when it was already hidden*.
+            // The original logic for hiding:
+            // header.classList.add('cv-header--hidden');
+            // tabsEl.classList.add('cv-tabs--fixed');
+            // headerState = 'hidden';
+            // The new behavior: if scrolling up, and header is floating, it stays floating.
+            // If not floating, and we are not at the top, it should become floating.
+            // This means the "hidden" state is only achieved if current logic for hiding is maintained
+            // for upward scrolls when header isn't already floating.
+            // Let's simplify: if scrolling up and not at top, and not floating, make it floating.
+            // This ensures header is visible as long as not at scrollY = 0.
+             if (headerState !== 'floating') {
+                header.classList.remove('cv-header--hidden');
+                header.classList.add('cv-header--floating');
+                tabsEl.classList.add('cv-tabs--fixed');
+                tabsEl.style.paddingTop = `${headerHeight}px`;
+                headerState = 'floating';
+             }
+          }
         }
       }
-      lastScroll = current;
+      lastScrollY = currentScrollY;
     }
 
     let ticking = false;
@@ -41,15 +105,26 @@ export function initHeaderTabsScroll() {
         ticking = true;
       }
     });
+
+    // Also listen for resize to update header height, as it might change with viewport
+    // Debounce resize listener for performance
+    let resizeTimeout;
+    window.addEventListener('resize', () => {
+        clearTimeout(resizeTimeout);
+        resizeTimeout = setTimeout(() => {
+            updateHeaderHeight();
+            // Re-apply styles if header is floating, as its height might have changed
+            if (headerState === 'floating') {
+                tabsEl.style.paddingTop = `${headerHeight}px`;
+            }
+        }, 100);
+    });
   }
 
   function tryInit() {
-    let tabsEl = pageMain.querySelector('.cv-tabs');
-    let scrollContainer = window;
-    if (!tabsEl) {
-      tabsEl = pageMain.querySelector('.cv-tab-content');
-      scrollContainer = tabsEl || window;
-    }
+    const tabsEl = pageMain.querySelector('.cv-tabs');
+    // The scroll container should always be window for this global header behavior.
+    const scrollContainer = window;
 
     if (tabsEl) {
       attachListener(tabsEl, scrollContainer);
@@ -58,10 +133,15 @@ export function initHeaderTabsScroll() {
     return false;
   }
 
+  // Initial check
   if (!tryInit()) {
-    const observer = new MutationObserver(() => {
-      if (tryInit()) {
-        observer.disconnect();
+    // If tabs are not immediately available (e.g. loaded dynamically), observe mutations
+    const observer = new MutationObserver((mutationsList, obs) => {
+      const tabsEl = pageMain.querySelector('.cv-tabs');
+      if (tabsEl) {
+        if (tryInit()) {
+          obs.disconnect(); // Stop observing once initialized
+        }
       }
     });
     observer.observe(pageMain, { childList: true, subtree: true });


### PR DESCRIPTION
Modifica o comportamento do cv-header e cv-tabs durante o scroll da página.

- Ao rolar para baixo, o cv-header torna-se visível e fixo no topo (flutuante), empurrando as cv-tabs para baixo, que também se tornam fixas.
- Ao rolar para cima, o header flutuante e as tabs fixas permanecem visíveis.
- Ao atingir o topo da página (scrollY = 0), o header e as tabs retornam ao seu estado padrão.
- Adiciona responsividade à altura do header em caso de resize da janela.
- Transições suaves foram implementadas para uma melhor experiência do usuário.