### PR TITLE
Fix header scroll behavior and update docs

### DIFF
--- a/IMPROVEMENTS_UI.md
+++ b/IMPROVEMENTS_UI.md
@@ -130,7 +130,7 @@ Diversos ajustes foram realizados para melhorar a experiência em dispositivos m
 
 ## 9. Header/MainNav/Tab Scroll Reactivity
 
-O comportamento dinâmico de compactar o cabeçalho ou fixar as abas durante a rolagem foi removido. O conteúdo rola normalmente sem que `cv-header` ou `cv-tabs` sofram alterações via JavaScript. Os estilos e scripts responsáveis por essa lógica também foram eliminados do projeto.
+O cabeçalho voltou a reagir à rolagem para otimizar o espaço em telas menores. Ao deslizar para baixo, o cabeçalho torna-se visível e as abas recebem a classe `cv-tabs--fixed`, permanecendo no topo. Ao rolar para cima (com a página já deslocada), aplica-se `cv-header--hidden`, ocultando o cabeçalho enquanto as abas seguem fixas. Quando o usuário retorna ao início da página, ambas as classes são removidas, restabelecendo o layout padrão. As transições utilizam `transform`/`opacity` com duração em torno de 300&nbsp;ms para suavidade.
 
 ## Conclusão
 

--- a/conViver.Web/js/headerTabsScroll.js
+++ b/conViver.Web/js/headerTabsScroll.js
@@ -8,6 +8,7 @@ export function initHeaderTabsScroll() {
   function attachListener(tabsEl, scrollContainer) {
     let lastScroll = scrollContainer === window ? window.scrollY : scrollContainer.scrollTop;
     let isHeaderHidden = false;
+    let areTabsFixed = false;
     const threshold = 10;
 
     function update() {
@@ -15,17 +16,32 @@ export function initHeaderTabsScroll() {
       const delta = current - lastScroll;
       if (Math.abs(delta) <= threshold) return;
 
-      if (delta > 0 && current > header.offsetHeight) {
-        if (!isHeaderHidden) {
-          header.classList.add('cv-header--hidden');
-          tabsEl.classList.add('cv-tabs--fixed');
-          isHeaderHidden = true;
+      if (current === 0) {
+        if (areTabsFixed) {
+          tabsEl.classList.remove('cv-tabs--fixed');
+          areTabsFixed = false;
         }
-      } else if (delta < 0 || current <= 0) {
         if (isHeaderHidden) {
           header.classList.remove('cv-header--hidden');
-          tabsEl.classList.remove('cv-tabs--fixed');
           isHeaderHidden = false;
+        }
+      } else if (delta > 0) {
+        if (!areTabsFixed) {
+          tabsEl.classList.add('cv-tabs--fixed');
+          areTabsFixed = true;
+        }
+        if (isHeaderHidden) {
+          header.classList.remove('cv-header--hidden');
+          isHeaderHidden = false;
+        }
+      } else if (delta < 0) {
+        if (!areTabsFixed) {
+          tabsEl.classList.add('cv-tabs--fixed');
+          areTabsFixed = true;
+        }
+        if (!isHeaderHidden) {
+          header.classList.add('cv-header--hidden');
+          isHeaderHidden = true;
         }
       }
       lastScroll = current;

--- a/conViver.Web/wwwroot/js/headerTabsScroll.js
+++ b/conViver.Web/wwwroot/js/headerTabsScroll.js
@@ -8,6 +8,7 @@ export function initHeaderTabsScroll() {
   function attachListener(tabsEl, scrollContainer) {
     let lastScroll = scrollContainer === window ? window.scrollY : scrollContainer.scrollTop;
     let isHeaderHidden = false;
+    let areTabsFixed = false;
     const threshold = 10;
 
     function update() {
@@ -15,17 +16,32 @@ export function initHeaderTabsScroll() {
       const delta = current - lastScroll;
       if (Math.abs(delta) <= threshold) return;
 
-      if (delta > 0 && current > header.offsetHeight) {
-        if (!isHeaderHidden) {
-          header.classList.add('cv-header--hidden');
-          tabsEl.classList.add('cv-tabs--fixed');
-          isHeaderHidden = true;
+      if (current === 0) {
+        if (areTabsFixed) {
+          tabsEl.classList.remove('cv-tabs--fixed');
+          areTabsFixed = false;
         }
-      } else if (delta < 0 || current <= 0) {
         if (isHeaderHidden) {
           header.classList.remove('cv-header--hidden');
-          tabsEl.classList.remove('cv-tabs--fixed');
           isHeaderHidden = false;
+        }
+      } else if (delta > 0) {
+        if (!areTabsFixed) {
+          tabsEl.classList.add('cv-tabs--fixed');
+          areTabsFixed = true;
+        }
+        if (isHeaderHidden) {
+          header.classList.remove('cv-header--hidden');
+          isHeaderHidden = false;
+        }
+      } else if (delta < 0) {
+        if (!areTabsFixed) {
+          tabsEl.classList.add('cv-tabs--fixed');
+          areTabsFixed = true;
+        }
+        if (!isHeaderHidden) {
+          header.classList.add('cv-header--hidden');
+          isHeaderHidden = true;
         }
       }
       lastScroll = current;


### PR DESCRIPTION
## Summary
- adjust headerTabsScroll logic so header shows on scroll down and hides on scroll up
- keep tabs fixed until the user scrolls to the top
- document new behavior in IMPROVEMENTS_UI.md

## Testing
- `dotnet test --no-build` *(fails: Could not complete due to network restrictions)*

------
https://chatgpt.com/codex/tasks/task_e_686b3112e5dc8332a56c8f93f732872b