### PR TITLE
Fix header scroll behavior and update docs

### DIFF
--- a/IMPROVEMENTS_UI.md
+++ b/IMPROVEMENTS_UI.md
@@ -130,7 +130,7 @@ Diversos ajustes foram realizados para melhorar a experiência em dispositivos m
 
 ## 9. Header/MainNav/Tab Scroll Reactivity
 
-O comportamento dinâmico de compactar o cabeçalho ou fixar as abas durante a rolagem foi removido. O conteúdo rola normalmente sem que `cv-header` ou `cv-tabs` sofram alterações via JavaScript. Os estilos e scripts responsáveis por essa lógica também foram eliminados do projeto.
+O cabeçalho voltou a reagir à rolagem para otimizar o espaço em telas menores. Ao deslizar para baixo, o cabeçalho é ocultado (`cv-header--hidden`) e as abas recebem a classe `cv-tabs--fixed`, permanecendo no topo. Ao rolar para cima (com a página já deslocada), o cabeçalho volta a aparecer e as abas continuam fixas. Quando o usuário retorna ao início da página, ambas as classes são removidas, restabelecendo o layout padrão. As transições utilizam `transform`/`opacity` com duração em torno de 300&nbsp;ms para suavidade.
 
 ## Conclusão
 

--- a/conViver.Web/js/headerTabsScroll.js
+++ b/conViver.Web/js/headerTabsScroll.js
@@ -8,6 +8,7 @@ export function initHeaderTabsScroll() {
   function attachListener(tabsEl, scrollContainer) {
     let lastScroll = scrollContainer === window ? window.scrollY : scrollContainer.scrollTop;
     let isHeaderHidden = false;
+    let areTabsFixed = false;
     const threshold = 10;
 
     function update() {
@@ -15,16 +16,31 @@ export function initHeaderTabsScroll() {
       const delta = current - lastScroll;
       if (Math.abs(delta) <= threshold) return;
 
-      if (delta > 0 && current > header.offsetHeight) {
-        if (!isHeaderHidden) {
-          header.classList.add('cv-header--hidden');
-          tabsEl.classList.add('cv-tabs--fixed');
-          isHeaderHidden = true;
+      if (current === 0) {
+        if (areTabsFixed) {
+          tabsEl.classList.remove('cv-tabs--fixed');
+          areTabsFixed = false;
         }
-      } else if (delta < 0 || current <= 0) {
         if (isHeaderHidden) {
           header.classList.remove('cv-header--hidden');
-          tabsEl.classList.remove('cv-tabs--fixed');
+          isHeaderHidden = false;
+        }
+      } else if (delta > 0) {
+        if (!areTabsFixed) {
+          tabsEl.classList.add('cv-tabs--fixed');
+          areTabsFixed = true;
+        }
+        if (!isHeaderHidden) {
+          header.classList.add('cv-header--hidden');
+          isHeaderHidden = true;
+        }
+      } else if (delta < 0) {
+        if (!areTabsFixed) {
+          tabsEl.classList.add('cv-tabs--fixed');
+          areTabsFixed = true;
+        }
+        if (isHeaderHidden) {
+          header.classList.remove('cv-header--hidden');
           isHeaderHidden = false;
         }
       }

--- a/conViver.Web/wwwroot/js/headerTabsScroll.js
+++ b/conViver.Web/wwwroot/js/headerTabsScroll.js
@@ -8,6 +8,7 @@ export function initHeaderTabsScroll() {
   function attachListener(tabsEl, scrollContainer) {
     let lastScroll = scrollContainer === window ? window.scrollY : scrollContainer.scrollTop;
     let isHeaderHidden = false;
+    let areTabsFixed = false;
     const threshold = 10;
 
     function update() {
@@ -15,16 +16,31 @@ export function initHeaderTabsScroll() {
       const delta = current - lastScroll;
       if (Math.abs(delta) <= threshold) return;
 
-      if (delta > 0 && current > header.offsetHeight) {
-        if (!isHeaderHidden) {
-          header.classList.add('cv-header--hidden');
-          tabsEl.classList.add('cv-tabs--fixed');
-          isHeaderHidden = true;
+      if (current === 0) {
+        if (areTabsFixed) {
+          tabsEl.classList.remove('cv-tabs--fixed');
+          areTabsFixed = false;
         }
-      } else if (delta < 0 || current <= 0) {
         if (isHeaderHidden) {
           header.classList.remove('cv-header--hidden');
-          tabsEl.classList.remove('cv-tabs--fixed');
+          isHeaderHidden = false;
+        }
+      } else if (delta > 0) {
+        if (!areTabsFixed) {
+          tabsEl.classList.add('cv-tabs--fixed');
+          areTabsFixed = true;
+        }
+        if (!isHeaderHidden) {
+          header.classList.add('cv-header--hidden');
+          isHeaderHidden = true;
+        }
+      } else if (delta < 0) {
+        if (!areTabsFixed) {
+          tabsEl.classList.add('cv-tabs--fixed');
+          areTabsFixed = true;
+        }
+        if (isHeaderHidden) {
+          header.classList.remove('cv-header--hidden');
           isHeaderHidden = false;
         }
       }


### PR DESCRIPTION
## Summary
- adjust headerTabsScroll logic: hide header while scrolling down, show on scroll up
- document correct reactive header behavior

## Testing
- `node -e "import('./conViver.Web/js/headerTabsScroll.js')"`
- `dotnet test --no-build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686b3112e5dc8332a56c8f93f732872b