### PR TITLE
Fix header compact reappearance and doc

### DIFF
--- a/IMPROVEMENTS_UI.md
+++ b/IMPROVEMENTS_UI.md
@@ -130,7 +130,8 @@ Diversos ajustes foram realizados para melhorar a experiência em dispositivos m
 
 ## 9. Header/MainNav/Tab Scroll Reactivity
 
-O comportamento dinâmico de compactar o cabeçalho ou fixar as abas durante a rolagem foi removido. O conteúdo rola normalmente sem que `cv-header` ou `cv-tabs` sofram alterações via JavaScript. Os estilos e scripts responsáveis por essa lógica também foram eliminados do projeto.
+O cabeçalho voltou a reagir à rolagem para otimizar o espaço em telas menores. Ao deslizar para baixo, o cabeçalho é ocultado (`cv-header--hidden`) e as abas recebem a classe `cv-tabs--fixed`, permanecendo no topo. Ao rolar para cima (com a página já deslocada), o cabeçalho reaparece de forma mais enxuta (`cv-header--compact`) e as abas continuam fixas. Quando o usuário retorna ao início da página, todas as classes são removidas, restabelecendo o layout padrão. As transições utilizam `transform`/`opacity` com duração em torno de 300&nbsp;ms para suavidade.
+O código agora garante que esse retorno ao estado inicial ocorra mesmo em gestos rápidos de toque, usando um limiar menor, verificando o topo a cada evento e escutando o evento de rolagem como `passive` para maior desempenho em dispositivos móveis.
 
 ## Conclusão
 

--- a/conViver.Web/css/components.css
+++ b/conViver.Web/css/components.css
@@ -409,6 +409,11 @@ html[data-theme="dark"] .cv-button--borderless:hover {
 .cv-header--hidden {
     transform: translateY(-100%);
 }
+.cv-header--compact {
+    padding-top: calc(var(--cv-header-padding-y) / 2);
+    padding-bottom: calc(var(--cv-header-padding-y) / 2);
+    min-height: calc(var(--cv-header-height) - 0.5rem);
+}
 .cv-header__container {
     display: flex;
     align-items: center;

--- a/conViver.Web/js/headerTabsScroll.js
+++ b/conViver.Web/js/headerTabsScroll.js
@@ -8,24 +8,61 @@ export function initHeaderTabsScroll() {
   function attachListener(tabsEl, scrollContainer) {
     let lastScroll = scrollContainer === window ? window.scrollY : scrollContainer.scrollTop;
     let isHeaderHidden = false;
+    let areTabsFixed = false;
+    let isHeaderCompact = false;
     const threshold = 10;
 
-    function update() {
-      const current = scrollContainer === window ? window.scrollY : scrollContainer.scrollTop;
-      const delta = current - lastScroll;
-      if (Math.abs(delta) <= threshold) return;
+    function clearState() {
+      if (areTabsFixed) {
+        tabsEl.classList.remove('cv-tabs--fixed');
+        areTabsFixed = false;
+      }
+      if (isHeaderHidden) {
+        header.classList.remove('cv-header--hidden');
+        isHeaderHidden = false;
+      }
+      if (isHeaderCompact) {
+        header.classList.remove('cv-header--compact');
+        isHeaderCompact = false;
+      }
+    }
 
-      if (delta > 0 && current > header.offsetHeight) {
+    function update() {
+      const current = Math.max(0, scrollContainer === window ? window.scrollY : scrollContainer.scrollTop);
+      if (current <= threshold) {
+        clearState();
+      }
+      const delta = current - lastScroll;
+      if (Math.abs(delta) <= threshold) {
+        lastScroll = current;
+        return;
+      }
+
+      if (delta > 0) {
+        if (!areTabsFixed) {
+          tabsEl.classList.add('cv-tabs--fixed');
+          areTabsFixed = true;
+        }
         if (!isHeaderHidden) {
           header.classList.add('cv-header--hidden');
-          tabsEl.classList.add('cv-tabs--fixed');
           isHeaderHidden = true;
         }
-      } else if (delta < 0 || current <= 0) {
+        if (isHeaderCompact) {
+          header.classList.remove('cv-header--compact');
+          isHeaderCompact = false;
+        }
+      } else {
+        if (!areTabsFixed) {
+          tabsEl.classList.add('cv-tabs--fixed');
+          areTabsFixed = true;
+        }
         if (isHeaderHidden) {
           header.classList.remove('cv-header--hidden');
-          tabsEl.classList.remove('cv-tabs--fixed');
           isHeaderHidden = false;
+        }
+        if (!isHeaderCompact && current > threshold) {
+          header.classList.add('cv-header--compact');
+          isHeaderCompact = true;
         }
       }
       lastScroll = current;
@@ -40,7 +77,7 @@ export function initHeaderTabsScroll() {
         });
         ticking = true;
       }
-    });
+    }, { passive: true });
   }
 
   function tryInit() {

--- a/conViver.Web/wwwroot/css/components.css
+++ b/conViver.Web/wwwroot/css/components.css
@@ -409,6 +409,11 @@ html[data-theme="dark"] .cv-button--borderless:hover {
 .cv-header--hidden {
     transform: translateY(-100%);
 }
+.cv-header--compact {
+    padding-top: calc(var(--cv-header-padding-y) / 2);
+    padding-bottom: calc(var(--cv-header-padding-y) / 2);
+    min-height: calc(var(--cv-header-height) - 0.5rem);
+}
 .cv-header__container {
     display: flex;
     align-items: center;

--- a/conViver.Web/wwwroot/js/headerTabsScroll.js
+++ b/conViver.Web/wwwroot/js/headerTabsScroll.js
@@ -8,24 +8,61 @@ export function initHeaderTabsScroll() {
   function attachListener(tabsEl, scrollContainer) {
     let lastScroll = scrollContainer === window ? window.scrollY : scrollContainer.scrollTop;
     let isHeaderHidden = false;
+    let areTabsFixed = false;
+    let isHeaderCompact = false;
     const threshold = 10;
 
-    function update() {
-      const current = scrollContainer === window ? window.scrollY : scrollContainer.scrollTop;
-      const delta = current - lastScroll;
-      if (Math.abs(delta) <= threshold) return;
+    function clearState() {
+      if (areTabsFixed) {
+        tabsEl.classList.remove('cv-tabs--fixed');
+        areTabsFixed = false;
+      }
+      if (isHeaderHidden) {
+        header.classList.remove('cv-header--hidden');
+        isHeaderHidden = false;
+      }
+      if (isHeaderCompact) {
+        header.classList.remove('cv-header--compact');
+        isHeaderCompact = false;
+      }
+    }
 
-      if (delta > 0 && current > header.offsetHeight) {
+    function update() {
+      const current = Math.max(0, scrollContainer === window ? window.scrollY : scrollContainer.scrollTop);
+      if (current <= threshold) {
+        clearState();
+      }
+      const delta = current - lastScroll;
+      if (Math.abs(delta) <= threshold) {
+        lastScroll = current;
+        return;
+      }
+
+      if (delta > 0) {
+        if (!areTabsFixed) {
+          tabsEl.classList.add('cv-tabs--fixed');
+          areTabsFixed = true;
+        }
         if (!isHeaderHidden) {
           header.classList.add('cv-header--hidden');
-          tabsEl.classList.add('cv-tabs--fixed');
           isHeaderHidden = true;
         }
-      } else if (delta < 0 || current <= 0) {
+        if (isHeaderCompact) {
+          header.classList.remove('cv-header--compact');
+          isHeaderCompact = false;
+        }
+      } else {
+        if (!areTabsFixed) {
+          tabsEl.classList.add('cv-tabs--fixed');
+          areTabsFixed = true;
+        }
         if (isHeaderHidden) {
           header.classList.remove('cv-header--hidden');
-          tabsEl.classList.remove('cv-tabs--fixed');
           isHeaderHidden = false;
+        }
+        if (!isHeaderCompact && current > threshold) {
+          header.classList.add('cv-header--compact');
+          isHeaderCompact = true;
         }
       }
       lastScroll = current;
@@ -40,7 +77,7 @@ export function initHeaderTabsScroll() {
         });
         ticking = true;
       }
-    });
+    }, { passive: true });
   }
 
   function tryInit() {


### PR DESCRIPTION
## Summary
- fine-tune header scroll logic to add a compact state
- ensure classes clear when reaching the top
- document the compact header behavior

## Testing
- `node -e "import('./conViver.Web/js/headerTabsScroll.js').then(()=>console.log('ok')).catch(console.error)"`
- `node -e "import('./conViver.Web/js/pageLoader.js').then(()=>console.log('ok')).catch(err=>{console.error('error', err.message);})"` *(fails: document is not defined)*
- `dotnet test --no-build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686b3112e5dc8332a56c8f93f732872b