### PR TITLE
Fix feed authorize roles

### DIFF
--- a/conViver.API/Controllers/FeedController.cs
+++ b/conViver.API/Controllers/FeedController.cs
@@ -12,7 +12,8 @@ namespace conViver.API.Controllers
 {
     [ApiController]
     [Route("/api/v1/feed")]
-    [Authorize(Roles = "Syndic,Resident,Tenant")] // Using roles consistent with other controllers
+    // Acesso restrito a moradores e síndicos
+    [Authorize(Roles = "Sindico,Morador")]
     public class FeedController : ControllerBase
     {
         private readonly FeedService _feedService;


### PR DESCRIPTION
## Summary
- use Portuguese role names for feed controller authorization

## Testing
- `dotnet test conViver.Tests/conViver.Tests.csproj --configuration Release`

------
https://chatgpt.com/codex/tasks/task_e_686c884c699c8332bde2af3bd55ad219