### PR TITLE
Remove redundant path base

### DIFF
--- a/conViver.API/Program.cs
+++ b/conViver.API/Program.cs
@@ -107,7 +107,10 @@ using (var scope = app.Services.CreateScope())
     DataSeeder.Seed(db);
 }
 
-app.UsePathBase("/api/v1");
+// The controllers already include the /api/v1 prefix in their routes,
+// so using UsePathBase would duplicate it. Removing to avoid double
+// prefixing routes.
+// app.UsePathBase("/api/v1");
 
 app.UseMiddleware<RequestLoggingMiddleware>();
 app.UseMiddleware<ExceptionMiddleware>();


### PR DESCRIPTION
## Summary
- comment out `UsePathBase` call

## Testing
- `dotnet test conViver.Tests/conViver.Tests.csproj -v minimal` *(fails: PorteiroEndpoint_ShouldAccept_PorteiroToken)*

------
https://chatgpt.com/codex/tasks/task_e_686c89e856d48332ade46cbdb24b6481