### PR TITLE
Move CORS call earlier

### DIFF
--- a/conViver.API/Program.cs
+++ b/conViver.API/Program.cs
@@ -99,6 +99,9 @@ builder.Services.AddSwaggerGen(c =>
 
 var app = builder.Build();
 
+// Enable CORS
+app.UseCors(AllowDevOrigins);
+
 using (var scope = app.Services.CreateScope())
 {
     var db = scope.ServiceProvider.GetRequiredService<ConViverDbContext>();
@@ -116,8 +119,6 @@ app.UseMiddleware<RequestLoggingMiddleware>();
 app.UseMiddleware<ExceptionMiddleware>();
 app.UseMiddleware<CachingMiddleware>();
 
-// Enable CORS
-app.UseCors(AllowDevOrigins);
 
 app.UseAuthentication();
 app.UseAuthorization();


### PR DESCRIPTION
## Summary
- call `UseCors` right after building the WebApplication so middleware can use the CORS policy

## Testing
- `dotnet test conViver.Tests/conViver.Tests.csproj -v minimal` *(fails: PorteiroEndpoint_ShouldAccept_PorteiroToken)*

------
https://chatgpt.com/codex/tasks/task_e_686dc223b20c8332862632d128a65bb7