### PR TITLE
Move CORS middleware earlier

### DIFF
--- a/conViver.API/Controllers/VisitantesController.cs
+++ b/conViver.API/Controllers/VisitantesController.cs
@@ -14,7 +14,7 @@ using conViver.Core.Interfaces; // Added for IUsuarioService
 namespace conViver.API.Controllers;
 
 [ApiController]
-[Route("api/visitantes")] // Changed route to be more generic, specific roles will protect endpoints
+[Route("api/v1/visitantes")] // Updated route to include API version prefix
 // [Authorize(Roles = "Sindico")] // Removed default authorization, will be per-endpoint
 public class VisitantesController : ControllerBase
 {

--- a/conViver.API/Program.cs
+++ b/conViver.API/Program.cs
@@ -112,12 +112,12 @@ using (var scope = app.Services.CreateScope())
 // prefixing routes.
 // app.UsePathBase("/api/v1");
 
+// Enable CORS as early as possible in the pipeline
+app.UseCors(AllowDevOrigins);
+
 app.UseMiddleware<RequestLoggingMiddleware>();
 app.UseMiddleware<ExceptionMiddleware>();
 app.UseMiddleware<CachingMiddleware>();
-
-// Enable CORS
-app.UseCors(AllowDevOrigins);
 
 app.UseAuthentication();
 app.UseAuthorization();

--- a/conViver.Tests/Infrastructure/DataSeederIntegrationTests.cs
+++ b/conViver.Tests/Infrastructure/DataSeederIntegrationTests.cs
@@ -126,7 +126,7 @@ public class DataSeederIntegrationTests
 
         var unidadeId = db.Unidades.First().Id;
         var visitanteDto = new VisitanteInputDto { UnidadeId = unidadeId, Nome = "Visitante" };
-        var response = await client.PostAsJsonAsync("api/visitantes/registrar-entrada", visitanteDto);
+        var response = await client.PostAsJsonAsync("visitantes/registrar-entrada", visitanteDto);
         response.StatusCode.Should().Be(System.Net.HttpStatusCode.Created);
     }
 }


### PR DESCRIPTION
## Summary
- reorder `UseCors` middleware to run before custom logging
- keep visitor API routes consistent with other controllers
- update integration test to new visitor route

## Testing
- `dotnet test conViver.Tests/conViver.Tests.csproj`

------
https://chatgpt.com/codex/tasks/task_e_686dc2240c4c833296b794a4a1911316