### PR TITLE
Atualiza variáveis de CORS na documentação

### DIFF
--- a/DEPLOY_GUIDE.md
+++ b/DEPLOY_GUIDE.md
@@ -29,7 +29,7 @@ REDIS_CONNECTION=localhost:6379 # Ou a string de conexão do seu provedor Redis
 # URLs
 BASE_URL=https://api.conviver.app # URL pública da API (exemplo)
 FRONTEND_URL=https://www.conviver.app # URL pública do Frontend Web (exemplo)
-API_CORS_ALLOWED_ORIGINS=https://www.conviver.app;http://localhost:3000 # Origens permitidas para CORS
+CorsSettings__AllowedOrigins=https://www.conviver.app;http://localhost:3000 # Origens permitidas para CORS (use o formato "origem1;origem2")
 
 No Azure App Service, use Configuration > Application settings para cadastrar essas mesmas variáveis.
 
@@ -109,7 +109,7 @@ az webapp config appsettings set \
     DB_CONNECTION="Host=<seu-db-server>.postgres.database.azure.com;Port=5432;Username=<admin>;Password=<senha>;Database=conviver;" \
     REDIS_CONNECTION="<seu-redis>.redis.cache.windows.net:6380,password=<chave>,ssl=True,abortConnect=False" \
     JWT_SECRET="<seu-jwt-secret-super-longo-e-seguro>" \
-    API_CORS_ALLOWED_ORIGINS="https://www.conviver.app;https://outro-dominio-front.com" \
+    CorsSettings__AllowedOrigins="https://www.conviver.app;https://outro-dominio-front.com" \
     ASPNETCORE_ENVIRONMENT="Production" # Garante que a API rode em modo de Produção
 ```
 

--- a/README.md
+++ b/README.md
@@ -150,7 +150,7 @@ dotnet build -t:Run -f net8.0-android
 | `REDIS_CONNECTION`            | String de conexão para o Redis.                                                                                                         | `localhost:6379,abortConnect=false`                       |
 | `USE_REDIS`                   | Quando `true`, a API usa Redis para cache HTTP. Defina `false` para cache em memória. | `true` |
 | `BASE_URL`                    | URL base pública da API, usada em contextos como geração de links em emails.                                                            | `https://sua-api.com/api/v1`                              |
-| `API_CORS_ALLOWED_ORIGINS`    | Define as origens permitidas para CORS na API. Valor em `conViver.API/appsettings.json` (ex: `CorsSettings:AllowedOrigins`).            | `http://localhost:3000;https://yourdomain.com`            |
+| `CorsSettings__AllowedOrigins` | Define as origens permitidas para CORS na API. Corresponde a `CorsSettings:AllowedOrigins` em `conViver.API/appsettings.json`. Separe múltiplas origens com ponto e vírgula (`origem1;origem2`). | `http://localhost:3000;https://yourdomain.com` |
 | `WEB_API_BASE_URL`            | Define a URL base da API para o cliente web. Valor em `conViver.Web/js/config.js` (ex: `window.APP_CONFIG.API_BASE_URL`).                | `http://localhost:5000`                            |
 
 `conViver.API/appsettings.Development.json` possui defaults seguros para desenvolvimento.


### PR DESCRIPTION
## Summary
- ajusta nomes das variáveis de ambiente relativas a CORS
- explica formato esperado `origem1;origem2`

## Testing
- `dotnet test --no-build` *(fails: dotnet not found)*

------
https://chatgpt.com/codex/tasks/task_e_686dc49bd0a883329f054455c0dad3fb