### PR TITLE
Refactor: Adjust modal header and close button styling

### DIFF
--- a/conViver.Web/css/components.css
+++ b/conViver.Web/css/components.css
@@ -788,7 +788,6 @@ body.has-bottom-nav #mainNav {
 
 
 .user-menu-modal .cv-modal-header {
-    padding: var(--cv-spacing-sm) var(--cv-spacing-md);
     min-height: auto;
     display: flex;
     flex-direction: column;

--- a/conViver.Web/css/styles.css
+++ b/conViver.Web/css/styles.css
@@ -1282,9 +1282,7 @@ html[data-theme="dark"] .cv-modal-header {
 /* If close button is always on right: */
 .cv-modal-header .cv-modal-close {
     position: absolute; /* Simpler to manage for true centering of title */
-    right: var(--cv-spacing-md);
-    top: 50%;
-    transform: translateY(-50%);
+    /* right: var(--cv-spacing-md); */    /* top: 50%; */    /* transform: translate(-50%); */
 }
 /* If title should be truly centered regardless of close button, and close is part of flex: */
 /* .cv-modal-header { justify-content: center; } */

--- a/conViver.Web/wwwroot/css/components.css
+++ b/conViver.Web/wwwroot/css/components.css
@@ -788,7 +788,6 @@ body.has-bottom-nav #mainNav {
 
 
 .user-menu-modal .cv-modal-header {
-    padding: var(--cv-spacing-sm) var(--cv-spacing-md);
     min-height: auto;
     display: flex;
     flex-direction: column;

--- a/conViver.Web/wwwroot/css/styles.css
+++ b/conViver.Web/wwwroot/css/styles.css
@@ -1282,9 +1282,7 @@ html[data-theme="dark"] .cv-modal-header {
 /* If close button is always on right: */
 .cv-modal-header .cv-modal-close {
     position: absolute; /* Simpler to manage for true centering of title */
-    right: var(--cv-spacing-md);
-    top: 50%;
-    transform: translateY(-50%);
+    /* right: var(--cv-spacing-md); */    /* top: 50%; */    /* transform: translate(-50%); */
 }
 /* If title should be truly centered regardless of close button, and close is part of flex: */
 /* .cv-modal-header { justify-content: center; } */
@@ -1442,6 +1440,7 @@ html[data-theme="dark"] .cv-modal-footer.cv-modal-footer--ios-alert .cv-button:a
     cursor: pointer;
     transition: background-color 0.2s ease, transform 0.15s ease-out, opacity 0.2s ease;
 }
+
 
 .cv-modal-close:hover,
 .cv-modal-close:focus {


### PR DESCRIPTION
- Removed specific positioning from .cv-modal-header .cv-modal-close to allow for more flexible alignment via global .cv-modal-close styles.
- Removed padding from .user-menu-modal .cv-modal-header for a more compact user menu appearance.