### PR TITLE
Add env fallback for CORS origins

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,7 +150,7 @@ dotnet build -t:Run -f net8.0-android
 | `REDIS_CONNECTION`            | String de conexão para o Redis.                                                                                                         | `localhost:6379,abortConnect=false`                       |
 | `USE_REDIS`                   | Quando `true`, a API usa Redis para cache HTTP. Defina `false` para cache em memória. | `true` |
 | `BASE_URL`                    | URL base pública da API, usada em contextos como geração de links em emails.                                                            | `https://sua-api.com/api/v1`                              |
-| `CorsSettings__AllowedOrigins` | Define as origens permitidas para CORS na API. Corresponde a `CorsSettings:AllowedOrigins` em `conViver.API/appsettings.json`. Separe múltiplas origens com ponto e vírgula (`origem1;origem2`). | `http://localhost:3000;https://yourdomain.com` |
+| `CorsSettings__AllowedOrigins` / `API_CORS_ALLOWED_ORIGINS` | Define as origens permitidas para CORS na API. Corresponde a `CorsSettings:AllowedOrigins` em `conViver.API/appsettings.json` ou à variável `API_CORS_ALLOWED_ORIGINS`. Separe múltiplas origens com ponto e vírgula (`origem1;origem2`). | `http://localhost:3000;https://yourdomain.com` |
 | `WEB_API_BASE_URL`            | Define a URL base da API para o cliente web. Valor em `conViver.Web/js/config.js` (ex: `window.APP_CONFIG.API_BASE_URL`).                | `http://localhost:5000`                            |
 
 `conViver.API/appsettings.Development.json` possui defaults seguros para desenvolvimento.

--- a/conViver.API/Program.cs
+++ b/conViver.API/Program.cs
@@ -7,6 +7,7 @@ using Microsoft.AspNetCore.Authentication.JwtBearer;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.IdentityModel.Tokens;
 using conViver.Application.Services; // Moved here
+using System.Linq;
 
 var builder = WebApplication.CreateBuilder(args);
 
@@ -20,8 +21,19 @@ var AllowDevOrigins = "_allowDevOrigins";
 
 var allowedOriginsString = builder.Configuration.GetSection("CorsSettings:AllowedOrigins").Value;
 var origins = !string.IsNullOrWhiteSpace(allowedOriginsString)
-              ? allowedOriginsString.Split(';', StringSplitOptions.RemoveEmptyEntries)
+              ? allowedOriginsString.Split(';')
               : Array.Empty<string>();
+
+if (origins.Length == 0 || string.IsNullOrWhiteSpace(origins[0]))
+{
+    var envOrigins = Environment.GetEnvironmentVariable("API_CORS_ALLOWED_ORIGINS");
+    if (!string.IsNullOrWhiteSpace(envOrigins))
+    {
+        origins = envOrigins.Split(';');
+    }
+}
+
+origins = origins.Where(o => !string.IsNullOrWhiteSpace(o)).ToArray();
 
 builder.Services.AddCors(options =>
 {


### PR DESCRIPTION
## Summary
- allow Program.cs to read `API_CORS_ALLOWED_ORIGINS` if `CorsSettings:AllowedOrigins` has an empty first item
- sanitize origins list to remove blanks
- document `API_CORS_ALLOWED_ORIGINS` alongside `CorsSettings__AllowedOrigins`

## Testing
- `dotnet test conViver.Tests/conViver.Tests.csproj --no-build --verbosity minimal`

------
https://chatgpt.com/codex/tasks/task_e_686dc90e3a048332aa181643576a0d8d